### PR TITLE
Mapping description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ target/
 .idea*
 *.iml
 *~
+
+*.swp

--- a/mapping.md
+++ b/mapping.md
@@ -152,6 +152,8 @@ Maps to a `nix.MultiTag` with `type = neo.spiketrain`.
     | SpikeTrain.description(string)         | MultiTag.definition(string)             |
     | SpikeTrain.file_origin(string)         | MultiTag.metadata(**Section**) [[1]](#notes) |
     | SpikeTrain.t_start(Quantity scalar)    | MultiTag.metadata(**Section**) [[1]](#notes) |
+    | SpikeTrain.t_stop(Quantity scalar)     | MultiTag.metadata(**Section**) [[1]](#notes) |
+    | SpikeTrain.left_sweep(Quantity scalar) | MultiTag.metadata(**Section**) [[1]](#notes) |
 
   - Objects
     - SpikeTrain.times(Quantity 1D):  

--- a/mapping.md
+++ b/mapping.md
@@ -204,6 +204,23 @@ Maps to a `nix.MultiTag` with `type = neo.spiketrain`.
 
 ## neo.Unit
 
+Maps to a `nix.Source` with `type = neo.unit`.
+
+  - Attributes
+
+    | Neo                           | NIX                                  |
+    |-------------------------------|--------------------------------------|
+    | Unit.name(string)                | Source.name(string)                   |
+    | Unit.description(string)         | Source.definition(string)             |
+    | Unit.file_origin(string)         | Source.metadata(**Section**) [[1]](#notes) |
+
+  - Objects
+    - Unit.spiketrains is represented by the `MultiTag` which references a given `nix.Source` object.
+    See the description of the mapping for [neo.RecordingChannelGroup](#neorecordingchannelgroup).
+
+
+-------
+
 ## Notes:
   1. The NIX objects each hold only one `metadata` attribute.
   Neo attributes such as `file_datetime` and `file_origin` are mapped to properties within the same `nix.Section` to which the `metadata` attribute refers.

--- a/mapping.md
+++ b/mapping.md
@@ -1,3 +1,55 @@
 # Data model mapping between Neo and NIX
 
+## neo.Block
+Maps directly to nix.Block.
+  - Attributes
 
+    | Neo                           | NIX                                  |
+    |-------------------------------|--------------------------------------|
+    | Block.name(string)            | Block.name(string)                   |
+    | Block.description(string)     | Block.definition(string)             |
+    | Block.rec_datetime(datetime)  | Block.date(date)                     |
+    | Block.file_datetime(datetime) | Block.metadata(**Section**) [Note 1] |
+    | Block.file_origin             | Block.metadata(**Section**) [Note 1] |
+
+  - Objects
+    - neo.Block.segments(**Segment**[]):  
+    Maps directly to nix.Block.groups(**Group**[]).
+    See neo.Segment section for details.
+    - neo.Block.recordingchannelgroups(**RecordingChannelGroup**[]):  
+    Maps to neo.Block.sources(**Source**[]) with `type = "neo.recordingchannelgroup"`.
+    See neo.RecordingChannelGroup section for details.
+
+## neo.Segment
+Maps directly to nix.Group.
+  - Attributes
+
+    | Neo                           | NIX                                  |
+    |-------------------------------|--------------------------------------|
+    | Block.name(string)            | Block.name(string)                   |
+    | Block.description(string)     | Block.definition(string)             |
+    | Block.rec_datetime(datetime)  | Block.date(date)                     |
+    | Block.file_datetime(datetime) | Block.metadata(**Section**) [Note 1] |
+    | Block.file_origin             | Block.metadata(**Section**) [Note 1] |
+
+  - Objects
+    - Segment.analogsignals(**AnalogSignal**[]) & Segment.irregularlysampledsignals(**IrregularlySampledSignal**[]):  
+    For each item in both lists, a neo.DataArray is created which holds the signal data and attributes.
+    See the neo.AnalogSignal and neo.IrregularlySampledSignal sections for details.
+      - Signal objects in Neo can be grouped, e.g., `Segment.analogsignals` is a list of `AnalogSignal` objects, each of which can hold multiple signals.
+      In order to be able to reconstruct the original signal groupings, all `DataArray` objects that belong to the same `AnalogSignal` (or `IrregularlySampledSignal`) have their `metadata` attribute point to the same `Section`.
+    - Segment.epochs(**Epoch**[]):  
+    For each item in Group.epochs, a neo.MultiTag is created with `type = neo.epoch`.
+    See the neo.Epoch section for details.
+    - Segment.events(**Event**[]):  
+    For each item in Group.epochs, a neo.MultiTag is created with `type = neo.event`.
+    See the neo.Event section for details.
+    - Segment.spiketrains(**SpikeTrain**[]):  
+    For each item in Group.epochs, a neo.MultiTag is created with `type = neo.spiketrain`.
+    See the neo.Event section for details.
+
+
+## Notes:
+  1. The nix objects each hold only one `metadata` attribute.
+  The `file_datetime` and `file_origin` Neo attributes are mapped to two properties within the same `nix.Section`.
+  The `Section.name` should match the corresponding NIX object `name`.

--- a/mapping.md
+++ b/mapping.md
@@ -10,8 +10,8 @@ Maps directly to `nix.Block`.
     | Block.name(string)            | Block.name(string)                   |
     | Block.description(string)     | Block.definition(string)             |
     | Block.rec_datetime(datetime)  | Block.date(date)                     |
-    | Block.file_datetime(datetime) | Block.metadata(**Section**) [Note 1] |
-    | Block.file_origin             | Block.metadata(**Section**) [Note 1] |
+    | Block.file_datetime(datetime) | Block.metadata(**Section**) [[1]](#notes) |
+    | Block.file_origin             | Block.metadata(**Section**) [[1]](#notes) |
 
   - Objects
     - neo.Block.segments(**Segment**[]):  
@@ -31,8 +31,8 @@ Maps directly to `nix.Group`.
     | Segment.name(string)            | Group.name(string)                   |
     | Segment.description(string)     | Group.definition(string)             |
     | Segment.rec_datetime(datetime)  | Group.date(date)                     |
-    | Segment.file_datetime(datetime) | Group.metadata(**Section**) [Note 1] |
-    | Segment.file_origin             | Group.metadata(**Section**) [Note 1] |
+    | Segment.file_datetime(datetime) | Group.metadata(**Section**) [[1]](#notes) |
+    | Segment.file_origin             | Group.metadata(**Section**) [[1]](#notes) |
 
   - Objects
     - Segment.analogsignals(**AnalogSignal**[]) & Segment.irregularlysampledsignals(**IrregularlySampledSignal**[]):  
@@ -64,10 +64,10 @@ Maps to nix.Source with `type = neo.recordingchannelgroup`.
     |-------------------------------------------|---------------------------------------|
     | RecordingChannelGroup.name(string)        | Source.name(string)                   |
     | RecordingChannelGroup.description(string) | Source.definition(string)             |
-    | RecordingChannelGroup.file_origin         | Source.metadata(**Section**) [Note 1] |
-    | RecordingChannelGroup.coordinates(Quantity2D) | Source.metadata(**Section**) [Note 1] |
-    | RecordingChannelGroup.channel_names(np.ndarray) | Source.metadata(**Section**) [Note 1] |
-    | RecordingChannelGroup.channel_indexes(np.ndarray) | Source.metadata(**Section**) [Note 1] |
+    | RecordingChannelGroup.file_origin         | Source.metadata(**Section**) [[1]](#notes) |
+    | RecordingChannelGroup.coordinates(Quantity2D) | Source.metadata(**Section**) [[1]](#notes) |
+    | RecordingChannelGroup.channel_names(np.ndarray) | Source.metadata(**Section**) [[1]](#notes) |
+    | RecordingChannelGroup.channel_indexes(np.ndarray) | Source.metadata(**Section**) [[1]](#notes) |
 
   - Objects
       - RecordingChannelGroup.units(**Unit**[]):  
@@ -88,7 +88,7 @@ Maps to nix.Source with `type = neo.recordingchannelgroup`.
 When it is a child of a `neo.Segment`, maps to a `nix.DataArray` with `type = neo.analogsignal`.
 
 When it is a child of a `neo.RecordingChannelGroup`, maps to a `nix.Source` with `type = neo.analogsignal`.
-The `nix.Source` object references a `nix.Section` in its `metadata` attribute, which is also referenced by the corresponding `nix.DataArray` [Note 2].
+The `nix.Source` object references a `nix.Section` in its `metadata` attribute, which is also referenced by the corresponding `nix.DataArray` [[2]](#notes).
 
 
 

--- a/mapping.md
+++ b/mapping.md
@@ -1,0 +1,3 @@
+# Data model mapping between Neo and NIX
+
+

--- a/mapping.md
+++ b/mapping.md
@@ -15,10 +15,10 @@ Maps directly to nix.Block.
   - Objects
     - neo.Block.segments(**Segment**[]):  
     Maps directly to nix.Block.groups(**Group**[]).
-    See the [neo.Segment](#neo.Segment) section for details.
+    See the [neo.Segment](#neosegment) section for details.
     - neo.Block.recordingchannelgroups(**RecordingChannelGroup**[]):  
     Maps to neo.Block.sources(**Source**[]) with `type = "neo.recordingchannelgroup"`.
-    See the [neo.RecordingChannelGroup](#neo.RecordingChannelGroup) section for details.
+    See the [neo.RecordingChannelGroup](#neorecordingchannelgroup) section for details.
 
 ## neo.Segment
 Maps directly to nix.Group.
@@ -37,21 +37,21 @@ Maps directly to nix.Group.
     For each item in both lists, a nix.DataArray is created which holds the signal data and attributes.
     The `type` attribute of the `DataArray` is set to `neo.analogsignal` or `neo.irregularlysampledsignal` accordingly.
     These are stored in the Group.data_arrays list.
-    See the [neo.AnalogSignal](#neo.AnalogSignal) and [neo.IrregularlySampledSignal](neo.IrregularlySampledSignal) sections for details.
+    See the [neo.AnalogSignal](#neoanalogsignal) and [neo.IrregularlySampledSignal](#neoirregularlysampledsignal) sections for details.
       - Signal objects in Neo can be grouped, e.g., `Segment.analogsignals` is a list of `AnalogSignal` objects, each of which can hold multiple signals.
       In order to be able to reconstruct the original signal groupings, all `DataArray` objects that belong to the same `AnalogSignal` (or `IrregularlySampledSignal`) have their `metadata` attribute point to the same `Section`.
     - Segment.epochs(**Epoch**[]):  
     For each item in Segment.epochs, a nix.MultiTag is created with `type = neo.epoch`.
     This is stored in the Group.multi_tags list.
-    See the [neo.Epoch](#neo.Epoch) section for details.
+    See the [neo.Epoch](#neoepoch) section for details.
     - Segment.events(**Event**[]):  
     For each item in Segment.events, a nix.MultiTag is created with `type = neo.event`.
     This is stored in the Group.multi_tags list.
-    See the [neo.Event](#neo.Event) section for details.
+    See the [neo.Event](#neoevent) section for details.
     - Segment.spiketrains(**SpikeTrain**[]):  
     For each item in Segment.spiketrains, a nix.MultiTag is created with `type = neo.spiketrain`.
     This is stored in the Group.multi_tags list.
-    See the [neo.SpikeTrain](#neo.SpikeTrain) section for details.
+    See the [neo.SpikeTrain](#neospiketrain) section for details.
 
 ## neo.RecordingChannelGroup
 Maps to nix.Source with `type = neo.recordingchannelgroup`.
@@ -70,7 +70,7 @@ Maps to nix.Source with `type = neo.recordingchannelgroup`.
       - RecordingChannelGroup.units(**Unit**[]):  
       For each item in RecordingChannelGroup.units, a nix.Source is created with `type = neo.unit`.
       This is stored in the Source.sources list.
-      See the [neo.Unit](#neo.Unit) section for details.
+      See the [neo.Unit](#neounit) section for details.
       - RecordingChannelGroup.analogsignals(**AnalogSignal**[]):  
       For each item in RecordingChannelGroup.analogsignals, a nix.Source is created with `type = neo.recordingchannelgroup`.
       This is stored in the Source.sources list.

--- a/mapping.md
+++ b/mapping.md
@@ -1,7 +1,8 @@
 # Data model mapping between Neo and NIX
 
 ## neo.Block
-Maps directly to nix.Block.
+
+Maps directly to `nix.Block`.
   - Attributes
 
     | Neo                           | NIX                                  |
@@ -21,7 +22,8 @@ Maps directly to nix.Block.
     See the [neo.RecordingChannelGroup](#neorecordingchannelgroup) section for details.
 
 ## neo.Segment
-Maps directly to nix.Group.
+
+Maps directly to `nix.Group`.
   - Attributes
 
     | Neo                             | NIX                                  |
@@ -34,26 +36,27 @@ Maps directly to nix.Group.
 
   - Objects
     - Segment.analogsignals(**AnalogSignal**[]) & Segment.irregularlysampledsignals(**IrregularlySampledSignal**[]):  
-    For each item in both lists, a nix.DataArray is created which holds the signal data and attributes.
+    For each item in both lists, a `nix.DataArray` is created which holds the signal data and attributes.
     The `type` attribute of the `DataArray` is set to `neo.analogsignal` or `neo.irregularlysampledsignal` accordingly.
-    These are stored in the Group.data_arrays list.
+    These are stored in the `Group.data_arrays` list.
     See the [neo.AnalogSignal](#neoanalogsignal) and [neo.IrregularlySampledSignal](#neoirregularlysampledsignal) sections for details.
       - Signal objects in Neo can be grouped, e.g., `Segment.analogsignals` is a list of `AnalogSignal` objects, each of which can hold multiple signals.
       In order to be able to reconstruct the original signal groupings, all `DataArray` objects that belong to the same `AnalogSignal` (or `IrregularlySampledSignal`) have their `metadata` attribute point to the same `Section`.
     - Segment.epochs(**Epoch**[]):  
-    For each item in Segment.epochs, a nix.MultiTag is created with `type = neo.epoch`.
-    This is stored in the Group.multi_tags list.
+    For each item in `Segment.epochs`, a `nix.MultiTag` is created with `type = neo.epoch`.
+    This is stored in the `Group.multi_tags` list.
     See the [neo.Epoch](#neoepoch) section for details.
     - Segment.events(**Event**[]):  
-    For each item in Segment.events, a nix.MultiTag is created with `type = neo.event`.
-    This is stored in the Group.multi_tags list.
+    For each item in `Segment.events`, a `nix.MultiTag` is created with `type = neo.event`.
+    This is stored in the `Group.multi_tags` list.
     See the [neo.Event](#neoevent) section for details.
     - Segment.spiketrains(**SpikeTrain**[]):  
-    For each item in Segment.spiketrains, a nix.MultiTag is created with `type = neo.spiketrain`.
-    This is stored in the Group.multi_tags list.
+    For each item in `Segment.spiketrains`, a `nix.MultiTag` is created with `type = neo.spiketrain`.
+    This is stored in the `Group.multi_tags` list.
     See the [neo.SpikeTrain](#neospiketrain) section for details.
 
 ## neo.RecordingChannelGroup
+
 Maps to nix.Source with `type = neo.recordingchannelgroup`.
   - Attributes
 
@@ -68,16 +71,16 @@ Maps to nix.Source with `type = neo.recordingchannelgroup`.
 
   - Objects
       - RecordingChannelGroup.units(**Unit**[]):  
-      For each item in RecordingChannelGroup.units, a nix.Source is created with `type = neo.unit`.
-      This is stored in the Source.sources list.
+      For each item in `RecordingChannelGroup.units`, a `nix.Source` is created with `type = neo.unit`.
+      This is stored in the `Source.sources` list.
       See the [neo.Unit](#neounit) section for details.
       - RecordingChannelGroup.analogsignals(**AnalogSignal**[]):  
-      For each item in RecordingChannelGroup.analogsignals, a nix.Source is created with `type = neo.recordingchannelgroup`.
-      This is stored in the Source.sources list.
+      For each item in `RecordingChannelGroup.analogsignals`, a `nix.Source` is created with `type = neo.recordingchannelgroup`.
+      This is stored in the `Source.sources` list.
       The child Source object contains a metadata (**Section**) reference which is also referenced by the relevant `DataArray`.
       - RecordingChannelGroup.irregularlysampledsignals(**IrregularlySampledSignal**[]):  
-      For each item in RecordingChannelGroup.IrregularlySampledSignal, a nix.Source is created with `type = neo.irregularlysampledsignals`.
-      This is stored in the Source.sources list.
+      For each item in `RecordingChannelGroup.IrregularlySampledSignal`, a `nix.Source` is created with `type = neo.irregularlysampledsignals`.
+      This is stored in the `Source.sources` list.
       The child Source object contains a metadata (**Section**) reference which is also referenced by the relevant `DataArray`.
 
 ## neo.AnalogSignal

--- a/mapping.md
+++ b/mapping.md
@@ -34,24 +34,54 @@ Maps directly to nix.Group.
 
   - Objects
     - Segment.analogsignals(**AnalogSignal**[]) & Segment.irregularlysampledsignals(**IrregularlySampledSignal**[]):  
-    For each item in both lists, a neo.DataArray is created which holds the signal data and attributes.
-    See the [neo.AnalogSignal](#neo.Analogsignal) and [neo.IrregularlySampledSignal](neo.IrregularlySampledSignal) sections for details.
+    For each item in both lists, a nix.DataArray is created which holds the signal data and attributes.
+    The `type` attribute of the `DataArray` is set to `neo.analogsignal` or `neo.irregularlysampledsignal` accordingly.
+    These are stored in the Group.data_arrays list.
+    See the [neo.AnalogSignal](#neo.AnalogSignal) and [neo.IrregularlySampledSignal](neo.IrregularlySampledSignal) sections for details.
       - Signal objects in Neo can be grouped, e.g., `Segment.analogsignals` is a list of `AnalogSignal` objects, each of which can hold multiple signals.
       In order to be able to reconstruct the original signal groupings, all `DataArray` objects that belong to the same `AnalogSignal` (or `IrregularlySampledSignal`) have their `metadata` attribute point to the same `Section`.
     - Segment.epochs(**Epoch**[]):  
-    For each item in Group.epochs, a neo.MultiTag is created with `type = neo.epoch`.
+    For each item in Segment.epochs, a nix.MultiTag is created with `type = neo.epoch`.
+    This is stored in the Group.multi_tags list.
     See the [neo.Epoch](#neo.Epoch) section for details.
     - Segment.events(**Event**[]):  
-    For each item in Group.epochs, a neo.MultiTag is created with `type = neo.event`.
+    For each item in Segment.events, a nix.MultiTag is created with `type = neo.event`.
+    This is stored in the Group.multi_tags list.
     See the [neo.Event](#neo.Event) section for details.
     - Segment.spiketrains(**SpikeTrain**[]):  
-    For each item in Group.epochs, a neo.MultiTag is created with `type = neo.spiketrain`.
+    For each item in Segment.spiketrains, a nix.MultiTag is created with `type = neo.spiketrain`.
+    This is stored in the Group.multi_tags list.
     See the [neo.SpikeTrain](#neo.SpikeTrain) section for details.
 
 ## neo.RecordingChannelGroup
+Maps to nix.Source with `type = neo.recordingchannelgroup`.
+  - Attributes
 
+    | Neo                                       | NIX                                   |
+    |-------------------------------------------|---------------------------------------|
+    | RecordingChannelGroup.name(string)        | Source.name(string)                   |
+    | RecordingChannelGroup.description(string) | Source.definition(string)             |
+    | RecordingChannelGroup.file_origin         | Source.metadata(**Section**) [Note 1] |
+    | RecordingChannelGroup.coordinates(Quantity2D) | Source.metadata(**Section**) [Note 1] |
+    | RecordingChannelGroup.channel_names(np.ndarray) | Source.metadata(**Section**) [Note 1] |
+    | RecordingChannelGroup.channel_indexes(np.ndarray) | Source.metadata(**Section**) [Note 1] |
+
+  - Objects
+      - RecordingChannelGroup.units(**Unit**[]):  
+      For each item in RecordingChannelGroup.units, a nix.Source is created with `type = neo.unit`.
+      This is stored in the Source.sources list.
+      See the [neo.Unit](#neo.Unit) section for details.
+      - RecordingChannelGroup.analogsignals(**AnalogSignal**[]):  
+      For each item in RecordingChannelGroup.analogsignals, a nix.Source is created with `type = neo.recordingchannelgroup`.
+      This is stored in the Source.sources list.
+      The child Source object contains a metadata (**Section**) reference which is also referenced by the relevant `DataArray`.
+      - RecordingChannelGroup.irregularlysampledsignals(**IrregularlySampledSignal**[]):  
+      For each item in RecordingChannelGroup.IrregularlySampledSignal, a nix.Source is created with `type = neo.irregularlysampledsignals`.
+      This is stored in the Source.sources list.
+      The child Source object contains a metadata (**Section**) reference which is also referenced by the relevant `DataArray`.
 
 ## Notes:
-  1. The nix objects each hold only one `metadata` attribute.
-  The `file_datetime` and `file_origin` Neo attributes are mapped to two properties within the same `nix.Section`.
+  1. The NIX objects each hold only one `metadata` attribute.
+  Neo attributes such as `file_datetime` and `file_origin` are mapped to properties within the same `nix.Section` to which the `metadata` attribute refers.
+  A metadata section is only created for a NIX object if necessary, i.e., it is not created if the Neo object attributes are not set.
   The `Section.name` should match the corresponding NIX object `name`.

--- a/mapping.md
+++ b/mapping.md
@@ -138,6 +138,22 @@ Maps to a `nix.DataArray` with `type = neo.irregularlysampledsignal`.
 
 ## neo.Epoch
 
+Maps to a `nix.MultiTag` with `type = neo.epoch`.
+
+  - Attributes
+
+    | Neo                           | NIX                                  |
+    |-------------------------------|--------------------------------------|
+    | Epoch.name(string)            | MultiTag.name(string)                   |
+    | Epoch.description(string)     | MultiTag.definition(string)             |
+    | Epoch.file_origin(string)     | MultiTag.metadata(**Section**) [[1]](#notes) |
+
+  - Objects
+    - Epoch.times(Quantity 1D) maps to `MultiTag.positions(DataArray)` with type `neo.epoch_times`.
+    - Epoch.durations(Quantity 1D) maps to `MultiTag.extents(DataArray)` with type `neo.epoch_durations`.
+    - Epoch.labels(string[]) maps to the `label` attribute of each `DataArray` referenced by `MultiTag.positions`.
+
+
 ## neo.Event
 
 ## neo.SpikeTrain

--- a/mapping.md
+++ b/mapping.md
@@ -80,6 +80,18 @@ Maps to nix.Source with `type = neo.recordingchannelgroup`.
       This is stored in the Source.sources list.
       The child Source object contains a metadata (**Section**) reference which is also referenced by the relevant `DataArray`.
 
+## neo.AnalogSignal
+
+## neo.IrregularlySampledSignal
+
+## neo.Epoch
+
+## neo.Event
+
+## neo.SpikeTrain
+
+## neo.Unit
+
 ## Notes:
   1. The NIX objects each hold only one `metadata` attribute.
   Neo attributes such as `file_datetime` and `file_origin` are mapped to properties within the same `nix.Section` to which the `metadata` attribute refers.

--- a/mapping.md
+++ b/mapping.md
@@ -87,10 +87,25 @@ Maps to nix.Source with `type = neo.recordingchannelgroup`.
 
 When it is a child of a `neo.Segment`, maps to a `nix.DataArray` with `type = neo.analogsignal`.
 
+  - Attributes
+
+    | Neo                           | NIX                                  |
+    |-------------------------------|--------------------------------------|
+    | AnalogSignal.name(string)            | DataArray.name(string)                   |
+    | AnalogSignal.description(string)     | DataArray.definition(string)             |
+    | AnalogSignal.file_origin             | DataArray.metadata(**Section**) [[1]](#notes) |
+
+  - Objects
+    - AnalogSignal.signal(Quantity 2D):  
+      - Maps directly to `DataArray.data(DataType[])`.
+      - Based on the units of the Quantity, `DataArray.unit(string)` is set.
+      - `DataArray.dimensions(Dimension[])` contains two objects, a `Sample` and a `Set` to denote that the first dimension of the data in the array represents regularly sampled data (`AnalogSignal`) and the second dimension simply represents a set of signals.
+    - AnalogSignal.sampling_rate(Quantity scalar)
+      - Maps to `DataArray.dimensions[0].sampling_interval`.
+    - AnalogSignal.t_start(Quantity scalar)
+
 When it is a child of a `neo.RecordingChannelGroup`, maps to a `nix.Source` with `type = neo.analogsignal` [[2]](#notes).
 The `nix.Source` object references a `nix.Section` in its `metadata` attribute, which is also referenced by the corresponding `nix.DataArray`.
-
-
 
 
 ## neo.IrregularlySampledSignal

--- a/mapping.md
+++ b/mapping.md
@@ -149,12 +149,27 @@ Maps to a `nix.MultiTag` with `type = neo.epoch`.
     | Epoch.file_origin(string)     | MultiTag.metadata(**Section**) [[1]](#notes) |
 
   - Objects
-    - Epoch.times(Quantity 1D) maps to `MultiTag.positions(DataArray)` with type `neo.epoch_times`.
-    - Epoch.durations(Quantity 1D) maps to `MultiTag.extents(DataArray)` with type `neo.epoch_durations`.
+    - Epoch.times(Quantity 1D) maps to `MultiTag.positions(DataArray)` with type `neo.epoch.times`.
+    - Epoch.durations(Quantity 1D) maps to `MultiTag.extents(DataArray)` with type `neo.epoch.durations`.
     - Epoch.labels(string[]) maps to the `label` attribute of each `DataArray` referenced by `MultiTag.positions`.
 
 
 ## neo.Event
+
+Maps to a `nix.MultiTag` with `type = neo.event`.
+
+  - Attributes
+
+    | Neo                           | NIX                                  |
+    |-------------------------------|--------------------------------------|
+    | Event.name(string)            | MultiTag.name(string)                   |
+    | Event.description(string)     | MultiTag.definition(string)             |
+    | Event.file_origin(string)     | MultiTag.metadata(**Section**) [[1]](#notes) |
+
+  - Objects
+    - Event.times(Quantity 1D) maps to `MultiTag.positions(DataArray)` with type `neo.event.times`.
+    - Event.labels(string[]) maps to the `label` attribute of each `DataArray` referenced by `MultiTag.positions`.
+
 
 ## neo.SpikeTrain
 

--- a/mapping.md
+++ b/mapping.md
@@ -82,6 +82,14 @@ Maps to nix.Source with `type = neo.recordingchannelgroup`.
 
 ## neo.AnalogSignal
 
+When it is a child of a `neo.Segment`, maps to a `nix.DataArray` with `type = neo.analogsignal`.
+
+When it is a child of a `neo.RecordingChannelGroup`, maps to a `nix.Source` with `type = neo.analogsignal`.
+The `nix.Source` object references a `nix.Section` in its `metadata` attribute, which is also referenced by the corresponding `nix.DataArray` [Note 2].
+
+
+
+
 ## neo.IrregularlySampledSignal
 
 ## neo.Epoch
@@ -97,3 +105,6 @@ Maps to nix.Source with `type = neo.recordingchannelgroup`.
   Neo attributes such as `file_datetime` and `file_origin` are mapped to properties within the same `nix.Section` to which the `metadata` attribute refers.
   A metadata section is only created for a NIX object if necessary, i.e., it is not created if the Neo object attributes are not set.
   The `Section.name` should match the corresponding NIX object `name`.
+  2. It may be useful if nix.Source objects which are used to refer to DataArrays have a suffix which denotes they are references.
+  For example, a nix.Source which is created to refer to a DataArray with type `neo.analogsignal`, would have a type attribute with value `neo.analogsignal_ref`.
+  The same rule could be applied to metadata sections.

--- a/mapping.md
+++ b/mapping.md
@@ -152,8 +152,6 @@ Maps to a `nix.MultiTag` with `type = neo.spiketrain`.
     | SpikeTrain.description(string)         | MultiTag.definition(string)             |
     | SpikeTrain.file_origin(string)         | MultiTag.metadata(**Section**) [[1]](#notes) |
     | SpikeTrain.t_start(Quantity scalar)    | MultiTag.metadata(**Section**) [[1]](#notes) |
-    | SpikeTrain.left_sweep(Quantity scalar) | MultiTag.metadata(**Section**) [[1]](#notes) |
-    | SpikeTrain.sampling_rate(Quantity scalar) | MultiTag.metadata(**Section**) [[1]](#notes) |
 
   - Objects
     - SpikeTrain.times(Quantity 1D):  

--- a/mapping.md
+++ b/mapping.md
@@ -9,9 +9,9 @@ Maps directly to `nix.Block`.
     |-------------------------------|--------------------------------------|
     | Block.name(string)            | Block.name(string)                   |
     | Block.description(string)     | Block.definition(string)             |
-    | Block.rec_datetime(datetime)  | Block.date(date)                     |
-    | Block.file_datetime(datetime) | Block.metadata(**Section**) [[1]](#notes) |
-    | Block.file_origin(string)     | Block.metadata(**Section**) [[1]](#notes) |
+    | Block.rec\_datetime(datetime)  | Block.created\_at(int)                |
+    | Block.file\_datetime(datetime) | Block.metadata(**Section**) [[1]](#notes) |
+    | Block.file\_origin(string)     | Block.metadata(**Section**) [[1]](#notes) |
 
   - Objects
     - neo.Block.segments(**Segment**[]):  
@@ -27,13 +27,13 @@ Maps directly to `nix.Block`.
 Maps directly to `nix.Group`.
   - Attributes
 
-    | Neo                             | NIX                                  |
-    |---------------------------------|--------------------------------------|
-    | Segment.name(string)            | Group.name(string)                   |
-    | Segment.description(string)     | Group.definition(string)             |
-    | Segment.rec_datetime(datetime)  | Group.date(date)                     |
-    | Segment.file_datetime(datetime) | Group.metadata(**Section**) [[1]](#notes) |
-    | Segment.file_origin(string)     | Group.metadata(**Section**) [[1]](#notes) |
+    | Neo                              | NIX                                  |
+    |----------------------------------|--------------------------------------|
+    | Segment.name(string)             | Group.name(string)                   |
+    | Segment.description(string)      | Group.definition(string)             |
+    | Segment.rec\_datetime(datetime)  | Group.created\_at(int)              |
+    | Segment.file\_datetime(datetime) | Group.metadata(**Section**) [[1]](#notes) |
+    | Segment.file\_origin(string)     | Group.metadata(**Section**) [[1]](#notes) |
 
   - Objects
     - Segment.analogsignals(**AnalogSignal**[]) & Segment.irregularlysampledsignals(**IrregularlySampledSignal**[]):  
@@ -70,15 +70,13 @@ Maps to nix.Source with `type = neo.recordingchannelgroup`.
     | RecordingChannelGroup.file_origin(string) | Source.metadata(**Section**) [[1]](#notes) |
     | RecordingChannelGroup.coordinates(Quantity 2D) | Source.metadata(**Section**) [[1]](#notes) |
 
-    - nix.Source requires a date attribute.
-    This is inherited from the parent nix.Block.
     - RecordingChannelGroup.channel_indexes:  
     Are not mapped into any NIX object or attribute.
     When converting from NIX to Neo, the channel indexes are reconstructed from the contained `nix.Source` objects [[2]](#notes).
 
 For each object contained in the group lists (`units`, `analogsignals`, `irregularlysampledsignals`), a child nix.Source is created with `type = neo.recordingchannel`.
 Each `Source.name` is taken from the `RecordingChannelGroup.channel_names` array.
-The sources also inherit the container's `date` and `metadata`.
+The sources also inherit the container's `metadata`.
 The `Source.definition` string is constructed by appending the `Source.name` to container's `Source.definition`.
 
 Each of the `nix.Source` objects that are created as children of a `neo.RecordingChannelGroup` are referenced by:

--- a/mapping.md
+++ b/mapping.md
@@ -100,13 +100,14 @@ Maps to a `nix.DataArray` with `type = neo.analogsignal`.
   - Objects
     - AnalogSignal.signal(Quantity 2D):  
       - Maps directly to `DataArray.data(DataType[])`.
-      - Based on the units of the Quantity, `DataArray.unit(string)` is set.
-      - `DataArray.dimensions(Dimension[])` contains two objects, a `Sample` and a `Set` to denote that the first dimension of the data in the array represents regularly sampled data (`AnalogSignal`) and the second dimension simply represents a set of signals.
-    - AnalogSignal.sampling_rate(Quantity scalar)
-      - Maps to `DataArray.dimensions[0].sampling_interval`.
-    - AnalogSignal.t_start(Quantity scalar)
-    - AnalogSignal.channel_indexes(
-
+      - `DataArray.unit(string)` is set based on the units of the Quantity array (`AnalogSignal.signal`).
+      - `DataArray.dimensions(Dimension[])` contains two objects:
+          - A `SampledDimension` to denote that the signals are regularly sampled.
+          The attributes of this dimension are:
+              - `sampling_interval` assigned from the value of `AnalogSignal.sampling_rate(Quantity scalar)`
+              - `offset` assigned from the value of `AnalogSignal.t_start(Quantity scalar)`
+              - `unit` inheriting the value of the `DataArray.unit`.
+        - A `SetDimension` to denote that the second dimension represents a set (collection) of signals.
 
 ## neo.IrregularlySampledSignal
 

--- a/mapping.md
+++ b/mapping.md
@@ -58,6 +58,7 @@ Maps directly to `nix.Group`.
 ## neo.RecordingChannelGroup
 
 Maps to nix.Source with `type = neo.recordingchannelgroup`.
+
   - Attributes
 
     | Neo                                       | NIX                                   |
@@ -65,27 +66,27 @@ Maps to nix.Source with `type = neo.recordingchannelgroup`.
     | RecordingChannelGroup.name(string)        | Source.name(string)                   |
     | RecordingChannelGroup.description(string) | Source.definition(string)             |
     | RecordingChannelGroup.file_origin         | Source.metadata(**Section**) [[1]](#notes) |
-    | RecordingChannelGroup.coordinates(Quantity2D) | Source.metadata(**Section**) [[1]](#notes) |
-    | RecordingChannelGroup.channel_names(np.ndarray) | Source.metadata(**Section**) [[1]](#notes) |
-    | RecordingChannelGroup.channel_indexes(np.ndarray) | Source.metadata(**Section**) [[1]](#notes) |
+    | RecordingChannelGroup.coordinates         | Source.metadata(**Section**) [[1]](#notes) |
 
-  - Objects
-      - RecordingChannelGroup.units(**Unit**[]):  
-      For each item in `RecordingChannelGroup.units`, a `nix.Source` is created with `type = neo.unit`.
-      This is stored in the `Source.sources` list.
-      See the [neo.Unit](#neounit) section for details.
-      - RecordingChannelGroup.analogsignals(**AnalogSignal**[]):  
-      For each item in `RecordingChannelGroup.analogsignals`, a `nix.Source` is created with `type = neo.recordingchannelgroup`.
-      This is stored in the `Source.sources` list.
-      The child Source object contains a metadata (**Section**) reference which is also referenced by the relevant `DataArray`.
-      - RecordingChannelGroup.irregularlysampledsignals(**IrregularlySampledSignal**[]):  
-      For each item in `RecordingChannelGroup.IrregularlySampledSignal`, a `nix.Source` is created with `type = neo.irregularlysampledsignals`.
-      This is stored in the `Source.sources` list.
-      The child Source object contains a metadata (**Section**) reference which is also referenced by the relevant `DataArray`.
+    - nix.Source requires a date attribute.
+    This is inherited from the parent nix.Block.
+    - RecordingChannelGroup.channel_indexes:  
+    Are not mapped into any NIX object or attribute.
+    When converting from NIX to Neo, the channel indexes are reconstructed from the contained `nix.Source` objects [[2]](#notes).
+
+For contained object in the group (`units`, `analogsignals`, `irregularlysampledsignals`), a child nix.Source is created with `type = neo.recordingchannel`.
+Each `Source.name` is taken from the `RecordingChannelGroup.channel_names` array.
+The sources also inherit the container's `date` and `metadata`.
+The `Source.definition` string is constructed by appending the `Source.name` to container's `Source.definition`.
+
+Each of the `nix.Source` objects that are created as children of a `neo.RecordingChannelGroup` are referenced by
+  - The corresponding `DataArray`, in the case of sources which were created from the `analogsignals` and `irregularlysampledsignals` lists.
+  - The corresponding `MultiTag`, in the case of sources which were created from the `units` list.
+
 
 ## neo.AnalogSignal
 
-When it is a child of a `neo.Segment`, maps to a `nix.DataArray` with `type = neo.analogsignal`.
+Maps to a `nix.DataArray` with `type = neo.analogsignal`.
 
   - Attributes
 
@@ -103,9 +104,7 @@ When it is a child of a `neo.Segment`, maps to a `nix.DataArray` with `type = ne
     - AnalogSignal.sampling_rate(Quantity scalar)
       - Maps to `DataArray.dimensions[0].sampling_interval`.
     - AnalogSignal.t_start(Quantity scalar)
-
-When it is a child of a `neo.RecordingChannelGroup`, maps to a `nix.Source` with `type = neo.analogsignal` [[2]](#notes).
-The `nix.Source` object references a `nix.Section` in its `metadata` attribute, which is also referenced by the corresponding `nix.DataArray`.
+    - AnalogSignal.channel_indexes(
 
 
 ## neo.IrregularlySampledSignal
@@ -123,6 +122,5 @@ The `nix.Source` object references a `nix.Section` in its `metadata` attribute, 
   Neo attributes such as `file_datetime` and `file_origin` are mapped to properties within the same `nix.Section` to which the `metadata` attribute refers.
   A metadata section is only created for a NIX object if necessary, i.e., it is not created if the Neo object attributes are not set.
   The `Section.name` should match the corresponding NIX object `name`.
-  2. It may be useful if nix.Source objects which are used to refer to DataArrays have a suffix which denotes they are references.
-  For example, a nix.Source which is created to refer to a DataArray with type `neo.analogsignal`, would have a type attribute with value `neo.analogsignal_ref`.
-  The same rule could be applied to metadata sections.
+  2. The role of `channel_indexes` in `neo.RecordingChannelGroup` is still unclear.
+  The mapping is still not complete and is therefore subject to change.

--- a/mapping.md
+++ b/mapping.md
@@ -142,6 +142,17 @@ Maps to a `nix.DataArray` with `type = neo.irregularlysampledsignal`.
 
 ## neo.SpikeTrain
 
+Maps to a `nix.MultiTag` with `type = neo.spiketrain`.
+
+  - Objects
+    - SpikeTrain.times(Quantity 1D):  
+    Maps directly to `MultiTag.positions(DataArray)`.
+      - The positions `DataArray` is of type `neo.spiketrain` and has a single `SetDimension`.
+    - SpikeTrain.t_start(Quantity scalar) [...]
+    - SpikeTrain.left_sweep(Quantity scalar) [...]
+    - SpikeTrain.sampling_rate(Quantity scalar) [...]
+
+
 ## neo.Unit
 
 ## Notes:

--- a/mapping.md
+++ b/mapping.md
@@ -11,7 +11,7 @@ Maps directly to `nix.Block`.
     | Block.description(string)     | Block.definition(string)             |
     | Block.rec_datetime(datetime)  | Block.date(date)                     |
     | Block.file_datetime(datetime) | Block.metadata(**Section**) [[1]](#notes) |
-    | Block.file_origin             | Block.metadata(**Section**) [[1]](#notes) |
+    | Block.file_origin(string)     | Block.metadata(**Section**) [[1]](#notes) |
 
   - Objects
     - neo.Block.segments(**Segment**[]):  
@@ -33,7 +33,7 @@ Maps directly to `nix.Group`.
     | Segment.description(string)     | Group.definition(string)             |
     | Segment.rec_datetime(datetime)  | Group.date(date)                     |
     | Segment.file_datetime(datetime) | Group.metadata(**Section**) [[1]](#notes) |
-    | Segment.file_origin             | Group.metadata(**Section**) [[1]](#notes) |
+    | Segment.file_origin(string)     | Group.metadata(**Section**) [[1]](#notes) |
 
   - Objects
     - Segment.analogsignals(**AnalogSignal**[]) & Segment.irregularlysampledsignals(**IrregularlySampledSignal**[]):  
@@ -67,8 +67,8 @@ Maps to nix.Source with `type = neo.recordingchannelgroup`.
     |-------------------------------------------|---------------------------------------|
     | RecordingChannelGroup.name(string)        | Source.name(string)                   |
     | RecordingChannelGroup.description(string) | Source.definition(string)             |
-    | RecordingChannelGroup.file_origin         | Source.metadata(**Section**) [[1]](#notes) |
-    | RecordingChannelGroup.coordinates         | Source.metadata(**Section**) [[1]](#notes) |
+    | RecordingChannelGroup.file_origin(string) | Source.metadata(**Section**) [[1]](#notes) |
+    | RecordingChannelGroup.coordinates(Quantity 2D) | Source.metadata(**Section**) [[1]](#notes) |
 
     - nix.Source requires a date attribute.
     This is inherited from the parent nix.Block.
@@ -84,7 +84,7 @@ The `Source.definition` string is constructed by appending the `Source.name` to 
 Each of the `nix.Source` objects that are created as children of a `neo.RecordingChannelGroup` are referenced by:
   - The corresponding `DataArray`, in the case of sources which were created from the `analogsignals` and `irregularlysampledsignals` lists.
   - The corresponding `MultiTag`, in the case of sources which were created from the `units` list.
-      - These `MultiTag` objects also contain a second `Source` with type `neo.unit`.
+      - These `MultiTag` objects also contain a second `Source` of type `neo.unit`.
 
 
 ## neo.AnalogSignal
@@ -97,7 +97,7 @@ Maps to a `nix.DataArray` with `type = neo.analogsignal`.
     |-------------------------------|--------------------------------------|
     | AnalogSignal.name(string)            | DataArray.name(string)                   |
     | AnalogSignal.description(string)     | DataArray.definition(string)             |
-    | AnalogSignal.file_origin             | DataArray.metadata(**Section**) [[1]](#notes) |
+    | AnalogSignal.file_origin(string)     | DataArray.metadata(**Section**) [[1]](#notes) |
 
   - Objects
     - AnalogSignal.signal(Quantity 2D):  
@@ -122,7 +122,7 @@ Maps to a `nix.DataArray` with `type = neo.irregularlysampledsignal`.
     |-------------------------------|--------------------------------------|
     | IrregularlySampledSignal.name(string)            | DataArray.name(string)                   |
     | IrregularlySampledSignal.description(string)     | DataArray.definition(string)             |
-    | IrregularlySampledSignal.file_origin             | DataArray.metadata(**Section**) [[1]](#notes) |
+    | IrregularlySampledSignal.file_origin(string)     | DataArray.metadata(**Section**) [[1]](#notes) |
 
   - Objects
     - IrregularlySampledSignal.signal(Quantity 2D):  
@@ -144,13 +144,31 @@ Maps to a `nix.DataArray` with `type = neo.irregularlysampledsignal`.
 
 Maps to a `nix.MultiTag` with `type = neo.spiketrain`.
 
+  - Attributes
+
+    | Neo                           | NIX                                  |
+    |-------------------------------|--------------------------------------|
+    | SpikeTrain.name(string)                | MultiTag.name(string)                   |
+    | SpikeTrain.description(string)         | MultiTag.definition(string)             |
+    | SpikeTrain.file_origin(string)         | MultiTag.metadata(**Section**) [[1]](#notes) |
+    | SpikeTrain.t_start(Quantity scalar)    | MultiTag.metadata(**Section**) [[1]](#notes) |
+    | SpikeTrain.left_sweep(Quantity scalar) | MultiTag.metadata(**Section**) [[1]](#notes) |
+    | SpikeTrain.sampling_rate(Quantity scalar) | MultiTag.metadata(**Section**) [[1]](#notes) |
+
   - Objects
     - SpikeTrain.times(Quantity 1D):  
     Maps directly to `MultiTag.positions(DataArray)`.
       - The positions `DataArray` is of type `neo.spiketrain` and has a single `SetDimension`.
-    - SpikeTrain.t_start(Quantity scalar) [...]
-    - SpikeTrain.left_sweep(Quantity scalar) [...]
-    - SpikeTrain.sampling_rate(Quantity scalar) [...]
+    - SpikeTrain.waveforms(Quantity 3D):  
+    Waveform data and metadata associated with spikes are stored in a `DataArray` of type `neo.waveforms`.
+    The `DataArray` is associated with the spiketrain `MultiTag` via a `nix.Feature`.
+    Specifically, `MultiTag.features` holds a reference to a single `Feature` with `link_type = indexed`.
+    `Feature.data` refers to the `DataArray` where the waveforms are stored.
+    The `DataArray` also refers to a `metadata` Section that stores the `left_sweep` value.
+    The `DataArray` has 3 dimensions:
+      - `SetDimension`.
+      - `SetDimension`.
+      - `SampledDimension`: The `SpikeTrain.sampling_rate` is stored in this dimension's `sampling_interval` and the `unit` is set accordingly.
 
 
 ## neo.Unit

--- a/mapping.md
+++ b/mapping.md
@@ -87,8 +87,8 @@ Maps to nix.Source with `type = neo.recordingchannelgroup`.
 
 When it is a child of a `neo.Segment`, maps to a `nix.DataArray` with `type = neo.analogsignal`.
 
-When it is a child of a `neo.RecordingChannelGroup`, maps to a `nix.Source` with `type = neo.analogsignal`.
-The `nix.Source` object references a `nix.Section` in its `metadata` attribute, which is also referenced by the corresponding `nix.DataArray` [[2]](#notes).
+When it is a child of a `neo.RecordingChannelGroup`, maps to a `nix.Source` with `type = neo.analogsignal` [[2]](#notes).
+The `nix.Source` object references a `nix.Section` in its `metadata` attribute, which is also referenced by the corresponding `nix.DataArray`.
 
 
 

--- a/mapping.md
+++ b/mapping.md
@@ -74,14 +74,15 @@ Maps to nix.Source with `type = neo.recordingchannelgroup`.
     Are not mapped into any NIX object or attribute.
     When converting from NIX to Neo, the channel indexes are reconstructed from the contained `nix.Source` objects [[2]](#notes).
 
-For contained object in the group (`units`, `analogsignals`, `irregularlysampledsignals`), a child nix.Source is created with `type = neo.recordingchannel`.
+For each object contained in the group lists (`units`, `analogsignals`, `irregularlysampledsignals`), a child nix.Source is created with `type = neo.recordingchannel`.
 Each `Source.name` is taken from the `RecordingChannelGroup.channel_names` array.
 The sources also inherit the container's `date` and `metadata`.
 The `Source.definition` string is constructed by appending the `Source.name` to container's `Source.definition`.
 
-Each of the `nix.Source` objects that are created as children of a `neo.RecordingChannelGroup` are referenced by
+Each of the `nix.Source` objects that are created as children of a `neo.RecordingChannelGroup` are referenced by:
   - The corresponding `DataArray`, in the case of sources which were created from the `analogsignals` and `irregularlysampledsignals` lists.
   - The corresponding `MultiTag`, in the case of sources which were created from the `units` list.
+      - These `MultiTag` objects also contain a second `Source` with type `neo.unit`.
 
 
 ## neo.AnalogSignal

--- a/mapping.md
+++ b/mapping.md
@@ -21,6 +21,7 @@ Maps directly to `nix.Block`.
     Maps to neo.Block.sources(**Source**[]) with `type = "neo.recordingchannelgroup"`.
     See the [neo.RecordingChannelGroup](#neorecordingchannelgroup) section for details.
 
+
 ## neo.Segment
 
 Maps directly to `nix.Group`.
@@ -54,6 +55,7 @@ Maps directly to `nix.Group`.
     For each item in `Segment.spiketrains`, a `nix.MultiTag` is created with `type = neo.spiketrain`.
     This is stored in the `Group.multi_tags` list.
     See the [neo.SpikeTrain](#neospiketrain) section for details.
+
 
 ## neo.RecordingChannelGroup
 
@@ -104,12 +106,35 @@ Maps to a `nix.DataArray` with `type = neo.analogsignal`.
       - `DataArray.dimensions(Dimension[])` contains two objects:
           - A `SampledDimension` to denote that the signals are regularly sampled.
           The attributes of this dimension are:
-              - `sampling_interval` assigned from the value of `AnalogSignal.sampling_rate(Quantity scalar)`
-              - `offset` assigned from the value of `AnalogSignal.t_start(Quantity scalar)`
+              - `sampling_interval` assigned from the value of `AnalogSignal.sampling_rate(Quantity scalar)`.
+              - `offset` assigned from the value of `AnalogSignal.t_start(Quantity scalar)`.
               - `unit` inheriting the value of the `DataArray.unit`.
         - A `SetDimension` to denote that the second dimension represents a set (collection) of signals.
 
+
 ## neo.IrregularlySampledSignal
+
+Maps to a `nix.DataArray` with `type = neo.irregularlysampledsignal`.
+
+  - Attributes
+
+    | Neo                           | NIX                                  |
+    |-------------------------------|--------------------------------------|
+    | IrregularlySampledSignal.name(string)            | DataArray.name(string)                   |
+    | IrregularlySampledSignal.description(string)     | DataArray.definition(string)             |
+    | IrregularlySampledSignal.file_origin             | DataArray.metadata(**Section**) [[1]](#notes) |
+
+  - Objects
+    - IrregularlySampledSignal.signal(Quantity 2D):  
+      - Maps directly to `DataArray.data(DataType[])`.
+      - `DataArray.unit(string)` is set based on the units of the Quantity array (`IrregularlySampledSignal.signal`).
+      - `DataArray.dimensions(Dimension[])` contains two objects:
+          - A `RangeDimension` to denote that the signals are irregularly sampled.
+          The attributes of this dimension are:
+              - `ticks` assigned from the value of `IrregularlySampledSignal.times(Quantity 1D)`.
+              - `unit` inheriting the value of the `DataArray.unit`.
+        - A `SetDimension` to denote that the second dimension represents a set (collection) of signals.
+
 
 ## neo.Epoch
 

--- a/mapping.md
+++ b/mapping.md
@@ -15,10 +15,10 @@ Maps directly to nix.Block.
   - Objects
     - neo.Block.segments(**Segment**[]):  
     Maps directly to nix.Block.groups(**Group**[]).
-    See neo.Segment section for details.
+    See [neo.Segment](#neo.segment) section for details.
     - neo.Block.recordingchannelgroups(**RecordingChannelGroup**[]):  
     Maps to neo.Block.sources(**Source**[]) with `type = "neo.recordingchannelgroup"`.
-    See neo.RecordingChannelGroup section for details.
+    See [neo.RecordingChannelGroup](#neo.recordingchannelgroup) section for details.
 
 ## neo.Segment
 Maps directly to nix.Group.
@@ -47,6 +47,8 @@ Maps directly to nix.Group.
     - Segment.spiketrains(**SpikeTrain**[]):  
     For each item in Group.epochs, a neo.MultiTag is created with `type = neo.spiketrain`.
     See the neo.Event section for details.
+
+## neo.RecordingChannelGroup
 
 
 ## Notes:

--- a/mapping.md
+++ b/mapping.md
@@ -15,38 +15,38 @@ Maps directly to nix.Block.
   - Objects
     - neo.Block.segments(**Segment**[]):  
     Maps directly to nix.Block.groups(**Group**[]).
-    See [neo.Segment](#neo.segment) section for details.
+    See the [neo.Segment](#neo.Segment) section for details.
     - neo.Block.recordingchannelgroups(**RecordingChannelGroup**[]):  
     Maps to neo.Block.sources(**Source**[]) with `type = "neo.recordingchannelgroup"`.
-    See [neo.RecordingChannelGroup](#neo.recordingchannelgroup) section for details.
+    See the [neo.RecordingChannelGroup](#neo.RecordingChannelGroup) section for details.
 
 ## neo.Segment
 Maps directly to nix.Group.
   - Attributes
 
-    | Neo                           | NIX                                  |
-    |-------------------------------|--------------------------------------|
-    | Block.name(string)            | Block.name(string)                   |
-    | Block.description(string)     | Block.definition(string)             |
-    | Block.rec_datetime(datetime)  | Block.date(date)                     |
-    | Block.file_datetime(datetime) | Block.metadata(**Section**) [Note 1] |
-    | Block.file_origin             | Block.metadata(**Section**) [Note 1] |
+    | Neo                             | NIX                                  |
+    |---------------------------------|--------------------------------------|
+    | Segment.name(string)            | Group.name(string)                   |
+    | Segment.description(string)     | Group.definition(string)             |
+    | Segment.rec_datetime(datetime)  | Group.date(date)                     |
+    | Segment.file_datetime(datetime) | Group.metadata(**Section**) [Note 1] |
+    | Segment.file_origin             | Group.metadata(**Section**) [Note 1] |
 
   - Objects
     - Segment.analogsignals(**AnalogSignal**[]) & Segment.irregularlysampledsignals(**IrregularlySampledSignal**[]):  
     For each item in both lists, a neo.DataArray is created which holds the signal data and attributes.
-    See the neo.AnalogSignal and neo.IrregularlySampledSignal sections for details.
+    See the [neo.AnalogSignal](#neo.Analogsignal) and [neo.IrregularlySampledSignal](neo.IrregularlySampledSignal) sections for details.
       - Signal objects in Neo can be grouped, e.g., `Segment.analogsignals` is a list of `AnalogSignal` objects, each of which can hold multiple signals.
       In order to be able to reconstruct the original signal groupings, all `DataArray` objects that belong to the same `AnalogSignal` (or `IrregularlySampledSignal`) have their `metadata` attribute point to the same `Section`.
     - Segment.epochs(**Epoch**[]):  
     For each item in Group.epochs, a neo.MultiTag is created with `type = neo.epoch`.
-    See the neo.Epoch section for details.
+    See the [neo.Epoch](#neo.Epoch) section for details.
     - Segment.events(**Event**[]):  
     For each item in Group.epochs, a neo.MultiTag is created with `type = neo.event`.
-    See the neo.Event section for details.
+    See the [neo.Event](#neo.Event) section for details.
     - Segment.spiketrains(**SpikeTrain**[]):  
     For each item in Group.epochs, a neo.MultiTag is created with `type = neo.spiketrain`.
-    See the neo.Event section for details.
+    See the [neo.SpikeTrain](#neo.SpikeTrain) section for details.
 
 ## neo.RecordingChannelGroup
 


### PR DESCRIPTION
Description of mappings from Neo objects to NIX. A part of the mapping is unfinished, specifically the `channel_indexes` of Neo's `RecordingChannelGroup`.

The mappings are based on the new Neo model (see NeuralEnsemble/python-neo#210).

This PR addresses issue #2.