### PR TITLE
Typo fix: neo.Block.sources -> nix.Block.sources

### DIFF
--- a/mapping.md
+++ b/mapping.md
@@ -18,7 +18,7 @@ Maps directly to `nix.Block`.
     Maps directly to nix.Block.groups(**Group**[]).
     See the [neo.Segment](#neosegment) section for details.
     - neo.Block.recordingchannelgroups(**RecordingChannelGroup**[]):  
-    Maps to neo.Block.sources(**Source**[]) with `type = "neo.recordingchannelgroup"`.
+    Maps to nix.Block.sources(**Source**[]) with `type = "neo.recordingchannelgroup"`.
     See the [neo.RecordingChannelGroup](#neorecordingchannelgroup) section for details.
 
 


### PR DESCRIPTION
A typo (neo instead of nix) in the mappings file has been fixed.