### PR TITLE
Test services: Travis and Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ addons:
       - g++-4.8
 
 install:
-    - pip install numpy quantities
+    - pip install numpy quantities coveralls
     # nix
     - git clone https://github.com/G-Node/nix.git nix
     - cd nix
@@ -50,4 +50,7 @@ install:
     - cd ..
 
 script:
-    nosetests
+    nosetests -v --with-coverage --cover-tests --cover-package=neonix
+
+after_success:
+    coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
         - CXX=g++-4.8
         - NIX_LIBDIR=./nix/inst/lib
         - NIX_INCDIR=./nix/inst/include
+        - export PKG_CONFIG_PATH=$NIX_LIBDIR/pkgconfig
         - export PYTHONPATH=$PYTHONPATH:$PWD/neo:$PWD/nixpy
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ env:
     global:
         - CC=gcc-4.8
         - CXX=g++-4.8
-        - NIX_LIBDIR=./nix/inst/lib
-        - NIX_INCDIR=./nix/inst/include
+        - NIX_LIBDIR=$PWD/nix/inst/lib
+        - NIX_INCDIR=$PWD/nix/inst/include
         - export PKG_CONFIG_PATH=$NIX_LIBDIR/pkgconfig
         - export PYTHONPATH=$PYTHONPATH:$PWD/neo:$PWD/nixpy
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,20 @@ env:
         - NIX_INCDIR=./nix/inst/include
         - export PYTHONPATH=$PYTHONPATH:$PWD/neo/:$PWD/nixpy/
 
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - kalakris-cmake
+      - boost-latest
+    packages:
+      - libcppunit-dev
+      - libboost1.55-all-dev
+      - libhdf5-serial-dev
+      - cmake
+      - g++-4.8
+
+
 install:
     - pip install numpy quantities
     # nix

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ addons:
       - cmake
       - g++-4.8
 
-
 install:
     - pip install numpy quantities
     # nix
@@ -45,3 +44,5 @@ install:
     - python setup.py build
     - cd ..
 
+script:
+    nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ install:
     - pip install numpy quantities
     # nix
     - git clone https://github.com/G-Node/nix.git nix
-    - cd nix-build
+    - cd nix
     - cmake -DCMAKE_INSTALL_PREFIX=./inst -DBUILD_TESTING=OFF .
     - make
     - make install
     - cd ..
     # nixpy
     - git clone https://github.com/G-Node/nixpy.git nixpy
-    - cd nixpy-build
+    - cd nixpy
     - python setup.py build
     - cd ..
     # neo

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ language: python
 
 python:
     - "2.7"
-    - "3.5"
+    - "3.2"
+      #- "3.5"
 
 env:
     global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ sudo: false
 
 language: python
 
-python:
-    - "2.7"
-    - "3.2"
-      #- "3.5"
+matrix:
+  include:
+    - python: "2.7_with_system_site_packages"
+      env: COVERALLS=1
+    - python: "3.2"
+      env: COVERALLS=0
 
 env:
     global:
@@ -50,7 +52,16 @@ install:
     - cd ..
 
 script:
-    nosetests -v --with-coverage --cover-tests --cover-package=neonix
+    - if [ $COVERALLS -eq 1 ]
+      then
+        nosetests -v --with-coverage --cover-tests --cover-package=neonix
+        coverage report
+      else
+        nosetests
+      fi
 
 after_success:
-    coverage report
+    - if [ $COVERALLS = 1 ]
+      then
+        coveralls
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
     - cd ..
 
 script:
-    - if [ $COVERALLS -eq 1 ]
+    - if [ $COVERALLS = 1 ]
       then
         nosetests -v --with-coverage --cover-tests --cover-package=neonix
         coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
         - CXX=g++-4.8
         - NIX_LIBDIR=./nix/inst/lib
         - NIX_INCDIR=./nix/inst/include
-        - export PYTHONPATH=$PYTHONPATH:$PWD/neo/:$PWD/nixpy/
+        - export PYTHONPATH=$PYTHONPATH:$PWD/neo:$PWD/nixpy
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+sudo: false
+
+language: python
+
+env:
+    global:
+        - CC=gcc-4.8
+        - CXX=g++-4.8
+        - NIX_LIBDIR=./nix/inst/lib
+        - NIX_INCDIR=./nix/inst/include
+        - export PYTHONPATH=$PYTHONPATH:$PWD/neo/:$PWD/nixpy/
+
+install:
+    - pip install numpy quantities
+    # nix
+    - git clone https://github.com/G-Node/nix.git nix
+    - cd nix-build
+    - cmake -DCMAKE_INSTALL_PREFIX=./inst -DBUILD_TESTING=OFF .
+    - make
+    - make install
+    - cd ..
+    # nixpy
+    - git clone https://github.com/G-Node/nixpy.git nixpy
+    - cd nixpy-build
+    - python setup.py build
+    - cd ..
+    # neo
+    - git clone https://github.com/apdavison/python-neo neo
+    - cd neo
+    - python setup.py build
+    - cd ..
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,16 +52,14 @@ install:
     - cd ..
 
 script:
-    - if [ $COVERALLS = 1 ]
-      then
-        nosetests -v --with-coverage --cover-tests --cover-package=neonix
-        coverage report
+    - if [ $COVERALLS = 1 ]; then
+        nosetests -v --with-coverage --cover-tests --cover-package=neonix;
+        coverage report;
       else
-        nosetests
-      fi
+        nosetests;
+      fi;
 
 after_success:
-    - if [ $COVERALLS = 1 ]
-      then
-        coveralls
-      fi
+    - if [ $COVERALLS = 1 ]; then
+        coveralls;
+      fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: false
 
 language: python
 
+python:
+    - "2.7"
+    - "3.5"
+
 env:
     global:
         - CC=gcc-4.8

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/G-Node/python-neo-nixio.svg?branch=master)](https://travis-ci.org/G-Node/python-neo-nixio)
+[![Coverage Status](https://coveralls.io/repos/github/G-Node/python-neo-nixio/badge.svg?branch=master)](https://coveralls.io/github/G-Node/python-neo-nixio?branch=master)
+
 # python-neo-nixio
 
 NIX IO for python-neo.


### PR DESCRIPTION
Adding Travis configuration file. Builds dependencies (nix, nixpy, and neo) and runs tests with coverage.
I've also added badges in the README that point to the predicted URLs for G-Node/master.

Requesting someone with admin rights for G-Node enable builds for NIXIO in Travis.