### PR TITLE
Improving test code

### DIFF
--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -190,7 +190,9 @@ class NixIO(BaseIO):
             if len(rcg.channel_names):
                 nix_chan_name = rcg.channel_names[idx]
             else:
-                nix_chan_name = "{}.{}".format(nix_name, idx)
+                nix_chan_name = "{}.RecordingChannel{}".format(
+                    parent_block.name, idx
+                )
             nix_chan_type = "neo.recordingchannel"
             nix_chan = nix_source.create_source(nix_chan_name, nix_chan_type)
             nix_chan.definition = nix_definition

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -105,17 +105,17 @@ class NixIOTest(unittest.TestCase):
             os.remove(self.filename)
 
     def test_block(self):
-        neo_block = Block(name="test_block", description="block for testing")
+        neo_block = Block(name=rand_word(), description=rand_sentence())
         nix_block = self.io.write_block(neo_block)
         self.assertEqual(nix_block.type, "neo.block")
         self.check_equal_attr(neo_block, nix_block)
 
     def test_block_cascade(self):
-        neo_block = Block(name="test_block", description="block for testing")
-        neo_segment = Segment(name="test_segment",
-                              description="segment for testing")
-        neo_rcg = RecordingChannelGroup(name="test_rcg",
-                                        description="rcg for testing",
+        neo_block = Block(name=rand_word(), description=rand_sentence())
+        neo_segment = Segment(name=rand_word(),
+                              description=rand_sentence(100))
+        neo_rcg = RecordingChannelGroup(name=rand_word(30),
+                                        description=rand_sentence(4),
                                         channel_indexes=[])
         neo_block.segments.append(neo_segment)
         neo_block.recordingchannelgroups.append(neo_rcg)
@@ -138,19 +138,19 @@ class NixIOTest(unittest.TestCase):
         self.check_equal_attr(neo_rcg, nix_source)
 
     def test_container_len_neq(self):
-        neo_block = Block(name="test_block", description="block for testing")
-        neo_segment = Segment(name="test_segment",
-                              description="segment for testing")
+        neo_block = Block(name=rand_word(20), description=rand_sentence(10, 10))
+        neo_segment = Segment(name=rand_sentence(3, 13),
+                              description=rand_sentence(10, 23))
         neo_block.segments.append(neo_segment)
         self.io.write_block(neo_block)
         nix_block = self.io.nix_file.blocks[0]
-        neo_segment_new = Segment(name="test_segment_2",
-                                  description="second segment for testing")
+        neo_segment_new = Segment(name=rand_word(40),
+                                  description=rand_sentence(6, 7))
         neo_block.segments.append(neo_segment_new)
         self.assertNotEqual(len(neo_block.segments), len(nix_block.groups))
 
     def test_block_metadata(self):
-        neo_block = Block(name="test_block", description="block for testing")
+        neo_block = Block(name=rand_word(44), description=rand_sentence(5))
         neo_block.rec_datetime = datetime(year=2015, month=12, day=18, hour=20)
         neo_block.file_datetime = datetime(year=2016, month=1, day=1, hour=15)
         neo_block.file_origin = "test_file_origin"

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -92,6 +92,9 @@ class NixIOTest(unittest.TestCase):
         """
         Create multiple trees that contain all types of objects, with no name or
         data to test the unique name generation.
+
+        Results are not checked. The purpose of this test it to check that the
+        data can be written without causing conflicts in NIX.
         """
         nblocks = 3
         nsegs = 4

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -177,6 +177,30 @@ class NixIOTest(unittest.TestCase):
                    if src.type == "neo.recordingchannelgroup"]
         self.check_equal_attr(rcg, nixrcgs[0])
 
+    def test_metadata_structure(self):
+        blk = NixIOTest.create_all_annotated()
+        blk = self.io.write_block(blk)
+
+        blkmd = blk.metadata
+        self.assertEqual(blk.name, blkmd.name)
+
+        grp = blk.groups[0]  # segment
+        self.assertIn(grp.name, blkmd.sections)
+
+        grpmd = blkmd.sections[grp.name]
+        for da in grp.data_arrays:  # signals
+            name = ".".join(da.name.split(".")[:-1])
+            self.assertIn(name, grpmd.sections)
+        for mtag in grp.multi_tags:  # spiketrains, events, and epochs
+            self.assertIn(mtag.name, grpmd.sections)
+
+        srcrcg = blk.sources[0]  # rcg
+        self.assertIn(srcrcg.name, blkmd.sections)
+        srcrcgmd = blkmd.sections[srcrcg.name]
+        for srcrc in srcrcg.sources:  # unit
+            if srcrc.type == "neo.unit":  # ignore channels - no metadata
+                self.assertIn(srcrc.name, srcrcgmd.sections)
+
     def test_waveforms(self):
         blk = Block()
         seg = Segment()

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -631,7 +631,7 @@ class NixIOTest(unittest.TestCase):
     def check_equal_attr(self, neoobj, nixobj):
         if neoobj.name:
             if isinstance(neoobj, (AnalogSignal, IrregularlySampledSignal)):
-                nix_name = "".join(nixobj.name.split(".")[:-1])
+                nix_name = ".".join(nixobj.name.split(".")[:-1])
             else:
                 nix_name = nixobj.name
             self.assertEqual(neoobj.name, nix_name)

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -138,75 +138,41 @@ class NixIOTest(unittest.TestCase):
         self.io.write_all_blocks(blocks)
 
     def test_annotations(self):
-        def rand_word():
-            return "".join(np.random.choice(list(string.ascii_letters), 10))
-
-        def rand_dict(nitems):
-            rd = dict()
-            for _ in range(nitems):
-                key = rand_word()
-                value = rand_word() if np.random.choice((0, 1))\
-                    else np.random.uniform()
-                rd[key] = value
-            return rd
-
-        times = np.array([1])*pq.s
-        signal = np.array([1])*pq.V
-        blk = Block()
-        blk.annotate(**rand_dict(3))
-
-        seg = Segment()
-        seg.annotate(**rand_dict(4))
-        blk.segments.append(seg)
-
-        asig = AnalogSignal(signal=signal, sampling_rate=pq.Hz)
-        asig.annotate(**rand_dict(2))
-        seg.analogsignals.append(asig)
-
-        isig = IrregularlySampledSignal(times=times, signal=signal,
-                                        time_units=pq.s)
-        isig.annotate(**rand_dict(2))
-        seg.irregularlysampledsignals.append(isig)
-
-        epoch = Epoch(times=times, durations=times)
-        epoch.annotate(**rand_dict(4))
-        seg.epochs.append(epoch)
-
-        event = Event(times=times)
-        event.annotate(**rand_dict(4))
-        seg.events.append(event)
-
-        spiketrain = SpikeTrain(times=times, t_stop=pq.s, units=pq.s)
-        spiketrain.annotate(**rand_dict(6))
-        seg.spiketrains.append(spiketrain)
-
-        rcg = RecordingChannelGroup(channel_indexes=[1, 2])
-        rcg.annotate(**rand_dict(4))
-        blk.recordingchannelgroups.append(rcg)
-
-        unit = Unit()
-        unit.annotate(**rand_dict(2))
-        rcg.units.append(unit)
+        blk = NixIOTest.create_all_annotated()
 
         nixblk = self.io.write_block(blk)
 
         self.check_equal_attr(blk, nixblk)
+
+        seg = blk.segments[0]
         self.check_equal_attr(seg, nixblk.groups[0])
+
+        asig = seg.analogsignals[0]
         for signal in [da for da in nixblk.data_arrays
                        if da.type == "neo.analogsignal"]:
             self.check_equal_attr(asig, signal)
+
+        isig = seg.irregularlysampledsignals[0]
         for signal in [da for da in nixblk.data_arrays
                        if da.type == "neo.irregularlysampledsignal"]:
             self.check_equal_attr(isig, signal)
+
+        epoch = seg.epochs[0]
         nixepochs = [mtag for mtag in nixblk.groups[0].multi_tags
                      if mtag.type == "neo.epoch"]
         self.check_equal_attr(epoch, nixepochs[0])
+
+        event = seg.events[0]
         nixevents = [mtag for mtag in nixblk.groups[0].multi_tags
                      if mtag.type == "neo.event"]
         self.check_equal_attr(event, nixevents[0])
+
+        spiketrain = seg.spiketrains[0]
         nixspiketrains = [mtag for mtag in nixblk.groups[0].multi_tags
                           if mtag.type == "neo.spiketrain"]
         self.check_equal_attr(spiketrain, nixspiketrains[0])
+
+        rcg = blk.recordingchannelgroups[0]
         nixrcgs = [src for src in nixblk.sources
                    if src.type == "neo.recordingchannelgroup"]
         self.check_equal_attr(rcg, nixrcgs[0])
@@ -660,4 +626,58 @@ class NixIOTest(unittest.TestCase):
             nixmd = nixobj.metadata
             for k, v, in neoobj.annotations.items():
                 self.assertEqual(nixmd[k], v)
+
+    @staticmethod
+    def create_all_annotated():
+        def rand_word():
+            return "".join(np.random.choice(list(string.ascii_letters), 10))
+
+        def rand_dict(nitems):
+            rd = dict()
+            for _ in range(nitems):
+                key = rand_word()
+                value = rand_word() if np.random.choice((0, 1)) \
+                    else np.random.uniform()
+                rd[key] = value
+            return rd
+
+        times = np.array([1])*pq.s
+        signal = np.array([1])*pq.V
+        blk = Block()
+        blk.annotate(**rand_dict(3))
+
+        seg = Segment()
+        seg.annotate(**rand_dict(4))
+        blk.segments.append(seg)
+
+        asig = AnalogSignal(signal=signal, sampling_rate=pq.Hz)
+        asig.annotate(**rand_dict(2))
+        seg.analogsignals.append(asig)
+
+        isig = IrregularlySampledSignal(times=times, signal=signal,
+                                        time_units=pq.s)
+        isig.annotate(**rand_dict(2))
+        seg.irregularlysampledsignals.append(isig)
+
+        epoch = Epoch(times=times, durations=times)
+        epoch.annotate(**rand_dict(4))
+        seg.epochs.append(epoch)
+
+        event = Event(times=times)
+        event.annotate(**rand_dict(4))
+        seg.events.append(event)
+
+        spiketrain = SpikeTrain(times=times, t_stop=pq.s, units=pq.s)
+        spiketrain.annotate(**rand_dict(6))
+        seg.spiketrains.append(spiketrain)
+
+        rcg = RecordingChannelGroup(channel_indexes=[1, 2])
+        rcg.annotate(**rand_dict(4))
+        blk.recordingchannelgroups.append(rcg)
+
+        unit = Unit()
+        unit.annotate(**rand_dict(2))
+        rcg.units.append(unit)
+
+        return blk
 


### PR DESCRIPTION
Separated test utility functions (random value generators) from the test class. Names and descriptions of generated Neo objects are now random strings, unless their names are specific for the write test. Signal and time arrays are random quantity arrays.

The purpose is to clean up the test class and make it easier to write more tests in the future without needing to specify values every time.

There is also a small fix for a problem with the naming convention for `RecordingChannel`s created from a `RecordingChannelGroup` that was discovered while checking the metadata section hierarchy.