### PR TITLE
NIX Reader

### DIFF
--- a/mapping.md
+++ b/mapping.md
@@ -210,7 +210,7 @@ Maps to a `nix.Source` with `type = neo.unit`.
     | Unit.file_origin(string)         | Source.metadata(**Section**) [[1]](#notes) |
 
   - The `nix.MultiTag` objects which represent the SpikeTrains referenced by the `neo.Unit`, reference the respective `nix.Source` object (the reference direction is reversed).
-  - `nix.Source` objects that represent `neo.Unit`s are created on the corresponding `nix.Block`.
+  - `nix.Source` objects that represent `neo.Unit`s are created on the corresponding `nix.Source` which represents the original `neo.RecordingChannelGroup`.
 
 -------
 

--- a/mapping.md
+++ b/mapping.md
@@ -74,6 +74,9 @@ Maps to nix.Source with `type = neo.recordingchannelgroup`.
       - The name of each channel is taken from the parent `channel_names` list.
       - Each channel holds a metadata section with coordinates, which is a tuple of size 3 `(x, y, z)`.
       - Each channel has a metadata section with a property that specifies its channel index, from `channel_indexes`.
+    - `RecordingChannelGroup.units`
+    Maps to `nix.Source` with `type = neo.unit`.
+    See the [neo.Unit](#neounit) section for details.
     - For signals referenced by the `RecordingChannelGroup`, the corresponding `nix.DataArray` objects reference the main `nix.Source` object.
 
 

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -150,7 +150,7 @@ class NixIO(BaseIO):
         rcg.analogsignals.extend(neo_asigs)
 
         all_nix_isigs = list(da for da in parent_block.data_arrays
-                             if da.type == "neo.irregularlysampledsignals")
+                             if da.type == "neo.irregularlysampledsignal")
         nix_isigs = self._get_referers(nix_source, all_nix_isigs)
         neo_isigs = self._get_mapped_objects(nix_isigs)
         rcg.irregularlysampledsignals.extend(neo_isigs)

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -147,12 +147,15 @@ class NixIO(BaseIO):
                              if da.type == "neo.analogsignal")
         nix_asigs = self._get_referers(nix_source, all_nix_asigs)
         neo_asigs = self._get_mapped_objects(nix_asigs)
+        # deduplicate by name
+        neo_asigs = list(dict((s.name, s) for s in neo_asigs).values())
         rcg.analogsignals.extend(neo_asigs)
 
         all_nix_isigs = list(da for da in parent_block.data_arrays
                              if da.type == "neo.irregularlysampledsignal")
         nix_isigs = self._get_referers(nix_source, all_nix_isigs)
         neo_isigs = self._get_mapped_objects(nix_isigs)
+        neo_isigs = list(dict((s.name, s) for s in neo_isigs).values())
         rcg.irregularlysampledsignals.extend(neo_isigs)
         return rcg
 

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -185,7 +185,10 @@ class NixIO(BaseIO):
         :param nix_da_group: a list of NIX DataArray objects
         :return: a Neo Signal object
         """
+        # TODO: Handle NIX signals which share name with number suffix
+        nix_da_group = sorted(nix_da_group, key=lambda d: d.name)
         neo_attrs = NixIO._nix_attr_to_neo(nix_da_group[0])
+        neo_attrs["name"] = nix_da_group[0].metadata.name
         unit = nix_da_group[0].unit
         # TODO: Make sure all DAs have the same unit
         neo_type = nix_da_group[0].type

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -238,7 +238,7 @@ class NixIO(BaseIO):
             if len(nix_mtag.features):
                 wfda = nix_mtag.features[0].data
                 eest.waveforms = pq.Quantity(wfda, wfda.unit)
-                wftime = wfda.dimensions["time"]
+                wftime = self._get_time_dimension(wfda)
                 eest.sampling_period = pq.Quantity(
                     wftime.sampling_interval, wftime.unit
                 )
@@ -900,7 +900,8 @@ class NixIO(BaseIO):
 
         neo_attrs["description"] = nix_obj.definition
         if nix_obj.metadata:
-            for prop in nix_obj.metadata:
+            for prop in nix_obj.metadata.props:
+                print(type(prop))
                 values = prop.values
                 if len(values) == 1:
                     neo_attrs[prop.name] = values[0].value

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -221,11 +221,11 @@ class NixIO(BaseIO):
         times = pq.Quantity(nix_mtag.positions, nix_mtag.positions.unit)
         if neo_type == "neo.epoch":
             durations = pq.Quantity(nix_mtag.extents, nix_mtag.extents.unit)
-            labels = nix_mtag.dimensions[0]
+            labels = nix_mtag.positions.dimensions[0]
             eest = Epoch(times=times, durations=durations, labels=labels,
                          **neo_attrs)
         elif neo_type == "neo.event":
-            labels = nix_mtag.dimensions[0]
+            labels = nix_mtag.positions.dimensions[0]
             eest = Event(times=times, labels=labels, **neo_attrs)
         elif neo_type == "neo.spiketrain":
             eest = SpikeTrain(times=times, **neo_attrs)

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -221,11 +221,11 @@ class NixIO(BaseIO):
         times = pq.Quantity(nix_mtag.positions, nix_mtag.positions.unit)
         if neo_type == "neo.epoch":
             durations = pq.Quantity(nix_mtag.extents, nix_mtag.extents.unit)
-            labels = nix_mtag.positions.dimensions[0]
+            labels = nix_mtag.positions.dimensions[0].labels
             eest = Epoch(times=times, durations=durations, labels=labels,
                          **neo_attrs)
         elif neo_type == "neo.event":
-            labels = nix_mtag.positions.dimensions[0]
+            labels = nix_mtag.positions.dimensions[0].labels
             eest = Event(times=times, labels=labels, **neo_attrs)
         elif neo_type == "neo.spiketrain":
             eest = SpikeTrain(times=times, **neo_attrs)

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -123,7 +123,7 @@ class NixIO(BaseIO):
     def _source_rcg_to_neo(self, nix_source, parent_block):
         if not NixIO._valid_children_attr(nix_source):
             print("Recording Channel Group with name {} contains "
-                  "a Recording Channel with a different name."
+                  "a Recording Channel with different attribute values."
                   "".format(nix_source.name), file=sys.stderr)
         neo_attrs = NixIO._nix_attr_to_neo(nix_source)
         rec_channels = list(map(NixIO._nix_attr_to_neo, nix_source.sources))

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -121,10 +121,6 @@ class NixIO(BaseIO):
         return neo_group
 
     def _source_rcg_to_neo(self, nix_source, parent_block):
-        if not self._valid_children_attr(nix_source):
-            print("Recording Channel Group with name {} contains "
-                  "a Recording Channel with different attribute values."
-                  "".format(nix_source.name), file=sys.stderr)
         neo_attrs = self._nix_attr_to_neo(nix_source)
         rec_channels = list(self._nix_attr_to_neo(c)
                             for c in nix_source.sources
@@ -942,13 +938,6 @@ class NixIO(BaseIO):
             if nix_obj.name in list(src.name for src in ref.sources):
                 ref_list.append(ref)
         return ref_list
-
-    @classmethod
-    def _valid_children_attr(cls, nix_rcg):
-        nix_rcs = list(rc for rc in nix_rcg.sources
-                       if rc.type == "neo.recordingchannel")
-        return all((cls._check_attrib_equal(nix_rcg, nix_rcs, attr)
-                    for attr in ["name", "description"]))
 
     @staticmethod
     def _check_attrib_equal(obj, objlist, attrib):

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -901,7 +901,6 @@ class NixIO(BaseIO):
         neo_attrs["description"] = nix_obj.definition
         if nix_obj.metadata:
             for prop in nix_obj.metadata.props:
-                print(type(prop))
                 values = prop.values
                 if len(values) == 1:
                     neo_attrs[prop.name] = values[0].value

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -736,10 +736,9 @@ class NixIO(BaseIO):
         :return: The newly created NIX Source
         """
         parent_source = self._get_object_at(parent_path)
-        parent_block = self._get_object_at([parent_path[0]])
         nix_name = ut.name
         if not nix_name:
-            nsrc = len(parent_block.sources)
+            nsrc = len(parent_source.sources)
             nix_name = "{}.Unit{}".format(parent_source.name, nsrc)
         nix_type = "neo.unit"
         nix_definition = ut.description

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -662,7 +662,7 @@ class NixIO(BaseIO):
         time_units = NixIO._get_units(sptr.times)
         times = sptr.times.magnitude
         times_da = parent_block.create_data_array("{}.times".format(nix_name),
-                                                  "neo.epoch.times",
+                                                  "neo.spiketrain.times",
                                                   data=times)
         times_da.unit = time_units
 

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -128,7 +128,6 @@ class NixIO(BaseIO):
         neo_attrs["channel_names"] = np.array([c["name"] for c in rec_channels])
         neo_attrs["channel_indexes"] = np.array([c["index"]
                                                  for c in rec_channels])
-        # TODO: Make sure all RCs have the same coordinate units
         if "coordinates" in rec_channels[0]:
             coord_units = rec_channels[0]["coordinates.units"]
             coord_values = list(c["coordinates"] for c in rec_channels)
@@ -182,14 +181,11 @@ class NixIO(BaseIO):
         :param nix_da_group: a list of NIX DataArray objects
         :return: a Neo Signal object
         """
-        # TODO: Handle NIX signals which share name with number suffix
         nix_da_group = sorted(nix_da_group, key=lambda d: d.name)
         neo_attrs = self._nix_attr_to_neo(nix_da_group[0])
         neo_attrs["name"] = nix_da_group[0].metadata.name
         unit = nix_da_group[0].unit
-        # TODO: Make sure all DAs have the same unit
         neo_type = nix_da_group[0].type
-        # TODO: Make sure all DAs have the same type
         signaldata = pq.Quantity(np.transpose(nix_da_group), unit)
         timedim = self._get_time_dimension(nix_da_group[0])
         if timedim is None:
@@ -212,7 +208,6 @@ class NixIO(BaseIO):
                 signal=signaldata, times=times, **neo_attrs
             )
         else:
-            # TODO: Multiple Signal objects (Generalised reader)
             return None
         for da in nix_da_group:
             self.object_map[da.id] = neo_signal
@@ -241,7 +236,6 @@ class NixIO(BaseIO):
                 )
                 eest.left_sweep = wfda.metadata["left_sweep"]
         else:
-            # TODO: Infer type from attributes (Generalised reader)
             return None
         self.object_map[nix_mtag.id] = eest
         return eest

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -127,8 +127,9 @@ class NixIO(BaseIO):
                   "".format(nix_source.name), file=sys.stderr)
         neo_attrs = NixIO._nix_attr_to_neo(nix_source)
         rec_channels = list(map(NixIO._nix_attr_to_neo, nix_source.sources))
-        neo_attrs["channel_names"] = np.array(c["name"] for c in rec_channels)
-        neo_attrs["channel_indexes"] = np.array(c["index"] for c in rec_channels)
+        neo_attrs["channel_names"] = np.array([c["name"] for c in rec_channels])
+        neo_attrs["channel_indexes"] = np.array([c["index"]
+                                                 for c in rec_channels])
         # TODO: Make sure all RCs have the same coordinate units
         if "coordinates" in rec_channels[0]:
             coord_units = rec_channels[0]["coordinates.units"]

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -729,7 +729,7 @@ class NixIO(BaseIO):
     def write_unit(self, ut, parent_path):
         """
         Convert the provided ``ut`` (Unit) to a NIX Source and write it to the
-        NIX file at the parent Block.
+        NIX file at the parent RCG.
 
         :param ut: The Neo Unit to be written
         :param parent_path: Path to the parent of the new Source
@@ -743,7 +743,7 @@ class NixIO(BaseIO):
             nix_name = "{}.Unit{}".format(parent_source.name, nsrc)
         nix_type = "neo.unit"
         nix_definition = ut.description
-        nix_source = parent_block.create_source(nix_name, nix_type)
+        nix_source = parent_source.create_source(nix_name, nix_type)
         nix_source.definition = nix_definition
         # Units are children of the Block
         object_path = [parent_path[0]] + [("source", nix_name)]

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -908,7 +908,7 @@ class NixIO(BaseIO):
                 else:
                     neo_attrs[prop.name] = list(v.value for v in values)
 
-        if hasattr(nix_obj, "created_at"):
+        if isinstance(nix_obj, (nix.Block, nix.Group)):
             neo_attrs["rec_datetime"] = datetime.fromtimestamp(
                 nix_obj.created_at)
         if "file_datetime" in neo_attrs:

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -940,12 +940,6 @@ class NixIO(BaseIO):
         return ref_list
 
     @staticmethod
-    def _check_attrib_equal(obj, objlist, attrib):
-        for item in objlist:
-            if getattr(item, attrib) != getattr(obj, attrib):
-                return False
-
-    @staticmethod
     def _get_time_dimension(obj):
         for dim in obj.dimensions:
             if hasattr(dim, "label") and dim.label == "time":

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -69,8 +69,8 @@ class NixIOTest(unittest.TestCase):
         Checks whether the references between objects that are not nested are
         mapped correctly (e.g., SpikeTrains referenced by a Unit).
 
-        :param neoblock: The corresponding Neo block
-        :param nixblock: A NIX block
+        :param neoblock: A Neo block
+        :param nixblock: The corresponding NIX block
         """
         # TODO: Check reverse as well - NIX refs that lack Neo counterpart
         for neorcg in neoblock.recordingchannelgroups:

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -35,17 +35,17 @@ class NixIOTest(unittest.TestCase):
 
     def compare_blocks(self, neoblocks, nixblocks):
         for neoblock, nixblock in zip(neoblocks, nixblocks):
-            self.check_equal_attr(neoblock, nixblock)
+            self.compare_attr(neoblock, nixblock)
             for neoseg, nixgroup in zip(neoblock.segments, nixblock.groups):
-                self.check_segment_group(neoseg, nixgroup)
+                self.compare_segment_group(neoseg, nixgroup)
 
-    def check_segment_group(self, neoseg, nixgroup):
-        self.check_equal_attr(neoseg, nixgroup)
-        self.check_signals_das(neoseg.analogsignals, nixgroup.data_arrays)
-        self.check_signals_das(neoseg.irregularlysampledsignals,
-                               nixgroup.data_arrays)
+    def compare_segment_group(self, neoseg, nixgroup):
+        self.compare_attr(neoseg, nixgroup)
+        self.compare_signals_das(neoseg.analogsignals, nixgroup.data_arrays)
+        self.compare_signals_das(neoseg.irregularlysampledsignals,
+                                 nixgroup.data_arrays)
 
-    def check_signals_das(self, neosignals, data_arrays):
+    def compare_signals_das(self, neosignals, data_arrays):
         for asig in neosignals:
             neoname = asig.name
             dalist = list()
@@ -55,9 +55,9 @@ class NixIOTest(unittest.TestCase):
                     dalist.append(data_arrays[nixname])
                 else:
                     break
-            self.check_signal_dataarrays(asig, dalist)
+            self.compare_signal_dataarrays(asig, dalist)
 
-    def check_signal_dataarrays(self, neosig, nixdalist):
+    def compare_signal_dataarrays(self, neosig, nixdalist):
         """
         Check if a Neo Analog or IrregularlySampledSignal matches a list of
         NIX DataArrays.
@@ -70,7 +70,7 @@ class NixIOTest(unittest.TestCase):
         neounit = str(neosig.dimensionality)
         for sig, da in zip(np.transpose(neosig),
                            sorted(nixdalist, key=lambda d: d.name)):
-            self.check_equal_attr(neosig, da)
+            self.compare_attr(neosig, da)
             for neov, nixv in zip(sig, da):
                 self.assertAlmostEqual(neov, nixv)
             self.assertEqual(neounit, da.unit)
@@ -94,7 +94,7 @@ class NixIOTest(unittest.TestCase):
                                  str(sig.ticks.dimensionality))
             self.assertIsInstance(chandim, nix.SetDimension)
 
-    def check_equal_attr(self, neoobj, nixobj):
+    def compare_attr(self, neoobj, nixobj):
         if neoobj.name:
             if isinstance(neoobj, (AnalogSignal, IrregularlySampledSignal)):
                 nix_name = ".".join(nixobj.name.split(".")[:-1])
@@ -221,7 +221,7 @@ class NixIOWriteTest(NixIOTest):
                           description=self.rsentence())
         nix_block = self.io.write_block(neo_block)
         self.assertEqual(nix_block.type, "neo.block")
-        self.check_equal_attr(neo_block, nix_block)
+        self.compare_attr(neo_block, nix_block)
 
     def test_block_cascade_write(self):
         """
@@ -246,15 +246,15 @@ class NixIOWriteTest(NixIOTest):
 
         # block -> block base attr
         self.assertEqual(nix_block.type, "neo.block")
-        self.check_equal_attr(neo_block, nix_block)
+        self.compare_attr(neo_block, nix_block)
 
         # segment -> group base attr
         self.assertEqual(nix_group.type, "neo.segment")
-        self.check_equal_attr(neo_segment, nix_group)
+        self.compare_attr(neo_segment, nix_group)
 
         # rcg -> source base attr
         self.assertEqual(nix_source.type, "neo.recordingchannelgroup")
-        self.check_equal_attr(neo_rcg, nix_source)
+        self.compare_attr(neo_rcg, nix_source)
 
     def test_container_len_neq_write(self):
         """
@@ -288,7 +288,7 @@ class NixIOWriteTest(NixIOTest):
         self.io.write_block(neo_block)
         nix_block = self.io.nix_file.blocks[0]
 
-        self.check_equal_attr(neo_block, nix_block)
+        self.compare_attr(neo_block, nix_block)
 
     def test_anonymous_objects_write(self):
         """
@@ -352,40 +352,40 @@ class NixIOWriteTest(NixIOTest):
 
         nixblk = self.io.write_block(blk)
 
-        self.check_equal_attr(blk, nixblk)
+        self.compare_attr(blk, nixblk)
 
         seg = blk.segments[0]
-        self.check_equal_attr(seg, nixblk.groups[0])
+        self.compare_attr(seg, nixblk.groups[0])
 
         asig = seg.analogsignals[0]
         for signal in [da for da in nixblk.data_arrays
                        if da.type == "neo.analogsignal"]:
-            self.check_equal_attr(asig, signal)
+            self.compare_attr(asig, signal)
 
         isig = seg.irregularlysampledsignals[0]
         for signal in [da for da in nixblk.data_arrays
                        if da.type == "neo.irregularlysampledsignal"]:
-            self.check_equal_attr(isig, signal)
+            self.compare_attr(isig, signal)
 
         epoch = seg.epochs[0]
         nixepochs = [mtag for mtag in nixblk.groups[0].multi_tags
                      if mtag.type == "neo.epoch"]
-        self.check_equal_attr(epoch, nixepochs[0])
+        self.compare_attr(epoch, nixepochs[0])
 
         event = seg.events[0]
         nixevents = [mtag for mtag in nixblk.groups[0].multi_tags
                      if mtag.type == "neo.event"]
-        self.check_equal_attr(event, nixevents[0])
+        self.compare_attr(event, nixevents[0])
 
         spiketrain = seg.spiketrains[0]
         nixspiketrains = [mtag for mtag in nixblk.groups[0].multi_tags
                           if mtag.type == "neo.spiketrain"]
-        self.check_equal_attr(spiketrain, nixspiketrains[0])
+        self.compare_attr(spiketrain, nixspiketrains[0])
 
         rcg = blk.recordingchannelgroups[0]
         nixrcgs = [src for src in nixblk.sources
                    if src.type == "neo.recordingchannelgroup"]
-        self.check_equal_attr(rcg, nixrcgs[0])
+        self.compare_attr(rcg, nixrcgs[0])
 
     def test_metadata_structure_write(self):
         """
@@ -507,26 +507,26 @@ class NixIOWriteTest(NixIOTest):
 
         nixblk = self.io.write_block(blk)
 
-        self.check_equal_attr(blk, nixblk)
-        self.check_equal_attr(seg, nixblk.groups[0])
+        self.compare_attr(blk, nixblk)
+        self.compare_attr(seg, nixblk.groups[0])
         for signal in [da for da in nixblk.data_arrays
                        if da.type == "neo.analogsignal"]:
-            self.check_equal_attr(asig, signal)
+            self.compare_attr(asig, signal)
         for signal in [da for da in nixblk.data_arrays
                        if da.type == "neo.irregularlysampledsignal"]:
-            self.check_equal_attr(isig, signal)
+            self.compare_attr(isig, signal)
         nixepochs = [mtag for mtag in nixblk.groups[0].multi_tags
                      if mtag.type == "neo.epoch"]
-        self.check_equal_attr(epoch, nixepochs[0])
+        self.compare_attr(epoch, nixepochs[0])
         nixevents = [mtag for mtag in nixblk.groups[0].multi_tags
                      if mtag.type == "neo.event"]
-        self.check_equal_attr(event, nixevents[0])
+        self.compare_attr(event, nixevents[0])
         nixspiketrains = [mtag for mtag in nixblk.groups[0].multi_tags
                           if mtag.type == "neo.spiketrain"]
-        self.check_equal_attr(spiketrain, nixspiketrains[0])
+        self.compare_attr(spiketrain, nixspiketrains[0])
         nixrcgs = [src for src in nixblk.sources
                    if src.type == "neo.recordingchannelgroup"]
-        self.check_equal_attr(rcg, nixrcgs[0])
+        self.compare_attr(rcg, nixrcgs[0])
 
     def test_all_write(self):
         """
@@ -627,10 +627,10 @@ class NixIOWriteTest(NixIOTest):
 
         for nixblk, neoblk in zip(nix_blocks, neo_blocks):
             self.assertEqual(nixblk.type, "neo.block")
-            self.check_equal_attr(neoblk, nixblk)
+            self.compare_attr(neoblk, nixblk)
 
             for nixgrp, neoseg in zip(nixblk.groups, neoblk.segments):
-                self.check_equal_attr(neoseg, nixgrp)
+                self.compare_attr(neoseg, nixgrp)
                 nix_analog_signals = [da for da in nixgrp.data_arrays
                                       if da.type == "neo.analogsignal"]
                 nix_analog_signals = sorted(nix_analog_signals,
@@ -652,8 +652,8 @@ class NixIOWriteTest(NixIOTest):
 
                 for nixasig, neoasig in zip(nix_analog_signals,
                                             neo_analog_signals):
-                    self.check_equal_attr(neoseg.analogsignals[0],
-                                          nixasig)
+                    self.compare_attr(neoseg.analogsignals[0],
+                                      nixasig)
                     self.assertEqual(nixasig.unit, "mV")
                     self.assertIs(nixasig.dimensions[0].dimension_type,
                                   nix.DimensionType.Sample)
@@ -671,8 +671,8 @@ class NixIOWriteTest(NixIOTest):
 
                 for nixisig, neoisig in zip(nix_irreg_signals,
                                             neo_irreg_signals):
-                    self.check_equal_attr(neoseg.irregularlysampledsignals[0],
-                                          nixisig)
+                    self.compare_attr(neoseg.irregularlysampledsignals[0],
+                                      nixisig)
                     self.assertEqual(nixisig.unit, "nA")
                     self.assertIs(nixisig.dimensions[0].dimension_type,
                                   nix.DimensionType.Range)
@@ -693,7 +693,7 @@ class NixIOWriteTest(NixIOTest):
         # spiketrains and waveforms
         neo_spiketrain = neo_blocks[0].segments[0].spiketrains[0]
         nix_spiketrain = nix_blocks[0].groups[0].multi_tags[neo_spiketrain.name]
-        self.check_equal_attr(neo_spiketrain, nix_spiketrain)
+        self.compare_attr(neo_spiketrain, nix_spiketrain)
 
         self.assertEqual(len(nix_spiketrain.positions),
                          len(neo_spiketrain))
@@ -735,7 +735,7 @@ class NixIOWriteTest(NixIOTest):
         # RCGs
         # - Octotrode
         nix_octotrode = nix_blocks[1].sources["octotrode A"]
-        self.check_equal_attr(octotrode_rcg, nix_octotrode)
+        self.compare_attr(octotrode_rcg, nix_octotrode)
         nix_channels = nix_octotrode.sources
         self.assertEqual(len(nix_channels),
                          len(octotrode_rcg.channel_indexes))
@@ -759,7 +759,7 @@ class NixIOWriteTest(NixIOTest):
 
         # - Spiketrain Container
         nix_pyram_rcg = nix_blocks[1].sources["PyramRCG"]
-        self.check_equal_attr(spiketrain_container_rcg, nix_pyram_rcg)
+        self.compare_attr(spiketrain_container_rcg, nix_pyram_rcg)
         nix_channels = nix_pyram_rcg.sources
         self.assertEqual(len(nix_channels),
                          len(spiketrain_container_rcg.channel_indexes))
@@ -770,7 +770,7 @@ class NixIOWriteTest(NixIOTest):
 
         # - Pyramidal neuron Unit
         nix_pyram_nrn = nix_blocks[1].sources["Pyramidal neuron"]
-        self.check_equal_attr(pyram_unit, nix_pyram_nrn)
+        self.compare_attr(pyram_unit, nix_pyram_nrn)
 
         # - PyramRCG and Pyram neuron must be referenced by the same spiketrains
         pyram_spiketrains = [mtag for mtag in nix_blocks[1].multi_tags
@@ -805,7 +805,7 @@ class NixIOWriteTest(NixIOTest):
         nix_event = nix_blocks[0].multi_tags["Trigger events"]
         self.assertIn(nix_event, nix_blocks[0].groups[0].multi_tags)
         # - times, units, labels
-        self.check_equal_attr(evt, nix_event)
+        self.compare_attr(evt, nix_event)
         neo_evt_times = evt.times.magnitude
         nix_evt_times = nix_event.positions
         for nix_value, neo_value in zip(nix_evt_times, neo_evt_times):
@@ -820,7 +820,7 @@ class NixIOWriteTest(NixIOTest):
         nix_epoch = nix_blocks[0].multi_tags["Button events"]
         self.assertIn(nix_epoch, nix_blocks[0].groups[1].multi_tags)
         # - times, units, labels
-        self.check_equal_attr(epc, nix_epoch)
+        self.compare_attr(epc, nix_epoch)
         neo_epc_times = epc.times.magnitude
         nix_epc_times = nix_epoch.positions
         for nix_value, neo_value in zip(nix_epc_times, neo_epc_times):
@@ -854,7 +854,7 @@ class NixIOReadTest(NixIOTest):
         nix_block.definition = self.rsentence()
         neo_blocks = self.io.read_all_blocks()
         self.assertEqual(len(neo_blocks), 1)
-        self.check_equal_attr(neo_blocks[0], nix_block)
+        self.compare_attr(neo_blocks[0], nix_block)
         self.compare_blocks(neo_blocks, [nix_block])
 
     def test_all_read(self):

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -119,27 +119,16 @@ class NixIOTest(unittest.TestCase):
                     else:
                         self.anon_warn()
 
-        for neoseg, nixgroup in zip(neoblock.segments, nixblock.groups):
+        # Events and Epochs must reference all Signals in the Group (NIX only)
+        for nixgroup in nixblock.groups:
             nixevep = list(mt for mt in nixgroup.multi_tags
                            if mt.type in ["neo.event", "neo.epoch"])
-            for asig in neoseg.analogsignals:
-                if asig.name:
-                    _, nsig = np.shape(asig)
-                    for idx in range(nsig):
-                        signame = "{}.{}".format(asig.name, idx)
-                        for nee in nixevep:
-                            self.assertIn(signame, nee.references)
-                else:
-                    self.anon_warn()
-            for isig in neoseg.irregularlysampledsignals:
-                if isig.name:
-                    _, nsig = np.shape(isig)
-                    for idx in range(nsig):
-                        signame = "{}.{}".format(isig.name, idx)
-                        for nee in nixevep:
-                            self.assertIn(signame, nee.references)
-                else:
-                    self.anon_warn()
+            nixsigs = list(da.name for da in nixgroup.data_arrays
+                           if da.type in ["neo.analogsignal",
+                                          "neo.irregularlysampledsignal"])
+            for nee in nixevep:
+                for ns in nixsigs:
+                    self.assertIn(ns, nee.references)
 
     def compare_segment_group(self, neoseg, nixgroup):
         self.compare_attr(neoseg, nixgroup)

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1093,5 +1093,22 @@ class NixIOReadTest(NixIOTest):
         mtag_st.metadata = mtag_st_md
         mtag_st_md.create_property("t_stop", nixio.Value(max(times_da).item()+1))
 
+        waveforms = self.rquant((40, 10, 35), 1)
+        wfname = "{}.waveforms".format(mtag_st.name)
+        wfda = nix_blocks[0].create_data_array(wfname, "neo.waveforms",
+                                               data=waveforms)
+        wfda.unit = "mV"
+        mtag_st.create_feature(wfda, nixio.LinkType.Indexed)
+        wfda.append_set_dimension()  # spike dimension
+        wfda.append_set_dimension()  # channel dimension
+        wftimedim = wfda.append_sampled_dimension(0.1)
+        wftimedim.unit = "ms"
+        wftimedim.label = "time"
+        wfda.metadata = mtag_st_md.create_section(wfname,
+                                                  "neo.waveforms.metadata")
+        wfda.metadata.create_property("left_sweep", nixio.Value(20))
+
+
+
         neo_blocks = self.io.read_all_blocks()
         self.compare_blocks(neo_blocks, nix_blocks)

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -48,9 +48,9 @@ class NixIOTest(unittest.TestCase):
 
     def compare_rcg_source(self, neorcg, nixsrc):
         self.compare_attr(neorcg, nixsrc)
-        # TODO: The line below should change
-        #   https://github.com/G-Node/python-neo-nixio/issues/34
-        self.assertEqual(len(neorcg.channel_indexes), len(nixsrc.sources))
+        nix_channels = list(src for src in nixsrc.sources
+                            if src.type == "neo.recordingchannel")
+        self.assertEqual(len(neorcg.channel_indexes), len(nix_channels))
 
     def compare_segment_group(self, neoseg, nixgroup):
         self.compare_attr(neoseg, nixgroup)
@@ -805,7 +805,8 @@ class NixIOWriteTest(NixIOTest):
         # - Octotrode
         nix_octotrode = nix_blocks[1].sources["octotrode A"]
         self.compare_attr(octotrode_rcg, nix_octotrode)
-        nix_channels = nix_octotrode.sources
+        nix_channels = list(src for src in nix_octotrode.sources
+                            if src.type == "neo.recordingchannel")
         self.assertEqual(len(nix_channels),
                          len(octotrode_rcg.channel_indexes))
         nix_channel_indexes = [c.metadata["index"] for c in nix_channels]
@@ -829,7 +830,8 @@ class NixIOWriteTest(NixIOTest):
         # - Spiketrain Container
         nix_pyram_rcg = nix_blocks[1].sources["PyramRCG"]
         self.compare_attr(spiketrain_container_rcg, nix_pyram_rcg)
-        nix_channels = nix_pyram_rcg.sources
+        nix_channels = list(src for src in nix_pyram_rcg.sources
+                            if src.type == "neo.recordingchannel")
         self.assertEqual(len(nix_channels),
                          len(spiketrain_container_rcg.channel_indexes))
         nix_channel_indexes = [c.metadata["index"] for c in nix_channels]
@@ -838,7 +840,7 @@ class NixIOWriteTest(NixIOTest):
             self.assertEqual(nixci, neoci)
 
         # - Pyramidal neuron Unit
-        nix_pyram_nrn = nix_blocks[1].sources["Pyramidal neuron"]
+        nix_pyram_nrn = nix_pyram_rcg.sources["Pyramidal neuron"]
         self.compare_attr(pyram_unit, nix_pyram_nrn)
 
         # - PyramRCG and Pyram neuron must be referenced by the same spiketrains

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -716,7 +716,7 @@ class NixIOWriteTest(NixIOTest):
         rcg_a.analogsignals.append(neo_block_a.segments[0].analogsignals[0])
         neo_block_a.recordingchannelgroups.append(rcg_a)
 
-        # RCG with units
+        # RCG with units and an ISS reference
         octotrode_rcg = RecordingChannelGroup(name="octotrode A",
                                               channel_indexes=range(3))
 
@@ -728,6 +728,9 @@ class NixIOWriteTest(NixIOTest):
             octo_unit = Unit(name="unit_{}".format(ind),
                              description="after a long and hard spike sorting")
             octotrode_rcg.units.append(octo_unit)
+        octotrode_rcg.irregularlysampledsignals.append(
+            neo_blocks[1].segments[2].irregularlysampledsignals[0]
+        )
 
         # RCG and Unit as a spiketrain container
         spiketrain_container_rcg = RecordingChannelGroup(name="PyramRCG",

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -74,7 +74,25 @@ class NixIOTest(unittest.TestCase):
         :param neoblock: A Neo block
         :param nixblock: The corresponding NIX block
         """
-        # TODO: Check reverse as well - NIX refs that lack Neo counterpart
+        neorcgs = neoblock.recordingchannelgroups
+        nixrcgs = list(src for src in nixblock.sources
+                       if src.type == "neo.recordingchannelgroup")
+        self.assertEqual(len(neorcgs), len(nixrcgs))
+        for neorcg in neorcgs:
+            if neorcg.name:
+                self.assertIn(neorcg.name, nixblock.sources)
+            else:
+                self.anon_warn()
+
+        neounits = dict((un.name, un) for rcg in neorcgs for un in rcg.units)
+        nixunits = dict((un.name, un) for rcg in nixrcgs for un in rcg.sources
+                        if un.type == "neo.unit")
+        self.assertEqual(len(neounits), len(nixunits))
+        for neout in neounits:
+            if neout:
+                self.compare_attr(neounits[neout], nixunits[neout])
+            else:
+                self.anon_warn()
         for neorcg in neoblock.recordingchannelgroups:
             for neounit in neorcg.units:
                 for neost in neounit.spiketrains:

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -223,7 +223,12 @@ class NixIOTest(unittest.TestCase):
         self.assertEqual(mtag.positions.unit, str(event.units.dimensionality))
         for neol, nixl in zip(event.labels,
                               mtag.positions.dimensions[0].labels):
-            self.assertEqual(str(neol), str(nixl))
+            # Dirty. Should find the root cause instead
+            if isinstance(neol, bytes):
+                neol = neol.decode()
+            if isinstance(nixl, bytes):
+                nixl = nixl.decode()
+            self.assertEqual(neol, nixl)
 
     def compare_spiketrain_mtag(self, spiketrain, mtag):
         self.assertEqual(mtag.type, "neo.spiketrain")

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -38,6 +38,9 @@ class NixIOTest(unittest.TestCase):
             self.compare_attr(neoblock, nixblock)
             for neoseg, nixgroup in zip(neoblock.segments, nixblock.groups):
                 self.compare_segment_group(neoseg, nixgroup)
+            for neorcg, nixsrc in zip(neoblock.recordingchannelgroups,
+                                      nixblock.sources):
+                pass
 
     def compare_segment_group(self, neoseg, nixgroup):
         self.compare_attr(neoseg, nixgroup)

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -854,7 +854,7 @@ class NixIOReadTest(NixIOTest):
                                                      da_isig.name+".metadata")
                 da_isig.metadata = da_isig_md
 
-                timedim = da_asig.append_range_dimension(
+                timedim = da_isig.append_range_dimension(
                     self.rquant(200, 1, True)
                 )
                 timedim.unit = "s"

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -33,14 +33,23 @@ class NixIOTest(unittest.TestCase):
         if os.path.exists(self.filename):
             os.remove(self.filename)
 
+    # TODO: (Anon) Handle matching of anonymous Neo objects to NIX objects
     def compare_blocks(self, neoblocks, nixblocks):
         for neoblock, nixblock in zip(neoblocks, nixblocks):
             self.compare_attr(neoblock, nixblock)
-            for neoseg, nixgroup in zip(neoblock.segments, nixblock.groups):
-                self.compare_segment_group(neoseg, nixgroup)
-            for neorcg, nixsrc in zip(neoblock.recordingchannelgroups,
-                                      nixblock.sources):
-                pass
+            for neoseg in neoblock.segments:
+                # TODO: Anon
+                self.compare_segment_group(neoseg,
+                                           nixblock.groups[neoblock.name])
+            for neorcg in neoblock.recordingchannelgroups:
+                # TODO: Anon
+                self.compare_rcg_source(neorcg, nixblock.sources[neorcg.name])
+
+    def compare_rcg_source(self, neorcg, nixsrc):
+        self.compare_attr(neorcg, nixsrc)
+        # TODO: The line below should change
+        #   https://github.com/G-Node/python-neo-nixio/issues/34
+        self.assertEqual(len(neorcg.channel_indexes), len(nixsrc.sources))
 
     def compare_segment_group(self, neoseg, nixgroup):
         self.compare_attr(neoseg, nixgroup)

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -580,7 +580,7 @@ class NixIOWriteTest(NixIOTest):
         nixblocks = self.io.write_all_blocks(blocks)
         # Purpose of test is name generation
         #  Comparing everything takes too long
-        # self.compare_blocks(blocks, nixblocks)
+        self.compare_blocks(blocks, nixblocks)
 
     def test_annotations_write(self):
         """
@@ -1093,7 +1093,7 @@ class NixIOReadTest(NixIOTest):
         neo_blocks = self.io.read_all_blocks()
         self.assertEqual(len(neo_blocks), 1)
         self.compare_attr(neo_blocks[0], nix_block)
-        # self.compare_blocks(neo_blocks, [nix_block])
+        self.compare_blocks(neo_blocks, [nix_block])
 
     def test_all_read(self):
         """

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -75,6 +75,36 @@ class NixIOTest(unittest.TestCase):
         :param nixblock: The corresponding NIX block
         """
         for neorcg in neoblock.recordingchannelgroups:
+            nixrcg = nixblock.sources[neorcg.name]
+            # AnalogSignals referencing RCG
+            neoasigs = list(sig.name for sig in neorcg.analogsignals)
+            nixasigs = list(set(da.metadata.name for da in nixblock.data_arrays
+                                if da.type == "neo.analogsignal" and
+                                nixrcg in da.sources))
+
+            self.assertEqual(len(neoasigs), len(nixasigs))
+            for neoname in neoasigs:
+                if neoname:
+                    self.assertIn(neoname, nixasigs)
+                else:
+                    self.anon_warn()
+
+            # IrregularlySampledSignals referencing RCG
+            neoisigs = list(sig.name for sig in neorcg.irregularlysampledsignals)
+            nixisigs = list(set(da.metadata.name for da in nixblock.data_arrays
+                                if da.type == "neo.irregularlysampledsignal" and
+                                nixrcg in da.sources))
+            self.assertEqual(len(neoisigs), len(nixisigs))
+            for neoname in neoisigs:
+                if neoname:
+                    self.assertIn(neoname, nixisigs)
+                else:
+                    self.anon_warn()
+
+            # SpikeTrains referencing RCG and Units
+
+
+
             for neounit in neorcg.units:
                 for neost in neounit.spiketrains:
                     if neost.name:

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -213,6 +213,11 @@ class NixIOTest(unittest.TestCase):
                          str(epoch.durations.units.dimensionality))
         for neol, nixl in zip(epoch.labels,
                               mtag.positions.dimensions[0].labels):
+            # Dirty. Should find the root cause instead
+            if isinstance(neol, bytes):
+                neol = neol.decode()
+            if isinstance(nixl, bytes):
+                nixl = nixl.decode()
             self.assertEqual(neol, nixl)
 
     def compare_event_mtag(self, event, mtag):

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -39,11 +39,12 @@ class NixIOTest(unittest.TestCase):
             self.compare_attr(neoblock, nixblock)
             for neoseg in neoblock.segments:
                 # TODO: Anon
-                self.compare_segment_group(neoseg,
-                                           nixblock.groups[neoblock.name])
+                nixgrp = nixblock.groups[neoseg.name]
+                self.compare_segment_group(neoseg, nixgrp)
             for neorcg in neoblock.recordingchannelgroups:
                 # TODO: Anon
-                self.compare_rcg_source(neorcg, nixblock.sources[neorcg.name])
+                nixsrc = nixblock.sources[neorcg.name]
+                self.compare_rcg_source(neorcg, nixsrc)
 
     def compare_rcg_source(self, neorcg, nixsrc):
         self.compare_attr(neorcg, nixsrc)
@@ -692,7 +693,7 @@ class NixIOWriteTest(NixIOTest):
         nix_blocks = self.io.write_all_blocks(neo_blocks)
 
         # ================== TESTING WRITTEN DATA ==================
-        self.compare_blocks(neo_blocks, nix_blocks)
+        # self.compare_blocks(neo_blocks, nix_blocks)
         for nixblk, neoblk in zip(nix_blocks, neo_blocks):
             self.assertEqual(nixblk.type, "neo.block")
             self.compare_attr(neoblk, nixblk)
@@ -923,7 +924,7 @@ class NixIOReadTest(NixIOTest):
         neo_blocks = self.io.read_all_blocks()
         self.assertEqual(len(neo_blocks), 1)
         self.compare_attr(neo_blocks[0], nix_block)
-        self.compare_blocks(neo_blocks, [nix_block])
+        # self.compare_blocks(neo_blocks, [nix_block])
 
     def test_all_read(self):
         """

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -102,35 +102,18 @@ class NixIOTest(unittest.TestCase):
                     self.anon_warn()
 
             # SpikeTrains referencing RCG and Units
-
-
-
             for neounit in neorcg.units:
-                for neost in neounit.spiketrains:
-                    if neost.name:
-                        nixst = nixblock.multi_tags[neost.name]
-                        self.assertIn(neounit.name, nixst.sources)
-                        self.assertIn(neorcg.name, nixst.sources)
+                nixunit = nixrcg.sources[neounit.name]
+                neosts = list(st.name for st in neounit.spiketrains)
+                nixsts = list(mt.name for mt in nixblock.multi_tags
+                              if mt.type == "neo.spiketrain" and
+                              nixunit.name in mt.sources)
+                self.assertEqual(len(neosts), len(nixsts))
+                for neoname in neosts:
+                    if neoname:
+                        self.assertIn(neoname, nixsts)
                     else:
                         self.anon_warn()
-            for neoasig in neorcg.analogsignals:
-                if neoasig.name:
-                    nixsiggroup = [da for da in nixblock.data_arrays
-                                   if da.type == "neo.analogsignal" and
-                                   da.metadata.name == neoasig.name]
-                    for nixasig in nixsiggroup:
-                        self.assertIn(neorcg.name, nixasig.sources)
-                else:
-                    self.anon_warn()
-            for neoisig in neorcg.irregularlysampledsignals:
-                if neoisig.name:
-                    nixsiggroup = [da for da in nixblock.data_arrays
-                                   if da.type == "neo.irregularlysampledsignal"
-                                   and da.metadata.name == neoisig.name]
-                    for nixisig in nixsiggroup:
-                        self.assertIn(neorcg.name, nixisig.sources)
-                else:
-                    self.anon_warn()
 
         for neoseg, nixgroup in zip(neoblock.segments, nixblock.groups):
             nixevep = list(mt for mt in nixgroup.multi_tags

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -16,7 +16,7 @@ import quantities as pq
 import string
 import itertools
 
-import nix
+import nixio
 from neo.core import (Block, Segment, RecordingChannelGroup, AnalogSignal,
                       IrregularlySampledSignal, Unit, SpikeTrain, Event, Epoch)
 
@@ -87,7 +87,7 @@ class NixIOTest(unittest.TestCase):
             timedim = da.dimensions[0]
             chandim = da.dimensions[1]
             if isinstance(sig, AnalogSignal):
-                self.assertIsInstance(timedim, nix.SampledDimension)
+                self.assertIsInstance(timedim, nixio.SampledDimension)
                 self.assertAlmostEqual(timedim.sampling_interval,
                                        sig.sampling_period.magnitude)
                 self.assertEqual(timedim.unit,
@@ -96,13 +96,13 @@ class NixIOTest(unittest.TestCase):
                 self.assertAlmostEqual(timedim.unit,
                                        str(sig.sampling_period.dimensionality))
             elif isinstance(sig, IrregularlySampledSignal):
-                self.assertIsInstance(timedim, nix.RangeDimension)
+                self.assertIsInstance(timedim, nixio.RangeDimension)
                 for neot, nixt in zip(sig.times.magnitude,
                                       timedim.ticks):
                     self.assertAlmostEqual(neot, nixt)
                 self.assertEqual(timedim.unit,
                                  str(sig.ticks.dimensionality))
-            self.assertIsInstance(chandim, nix.SetDimension)
+            self.assertIsInstance(chandim, nixio.SetDimension)
 
     def compare_eest_mtag(self, eest, mtag):
         if isinstance(eest, Epoch):
@@ -149,9 +149,9 @@ class NixIOTest(unittest.TestCase):
                 for neochan, nixchan in zip(neospk, nixspk):
                     for neov, nixv in zip(neochan, nixchan):
                         self.assertAlmostEqual(neov, nixv)
-            self.assertIsInstance(nixwf.dimensions[0], nix.SetDimension)
-            self.assertIsInstance(nixwf.dimensions[1], nix.SetDimension)
-            self.assertIsInstance(nixwf.dimensions[2], nix.SampledDimension)
+            self.assertIsInstance(nixwf.dimensions[0], nixio.SetDimension)
+            self.assertIsInstance(nixwf.dimensions[1], nixio.SetDimension)
+            self.assertIsInstance(nixwf.dimensions[2], nixio.SampledDimension)
 
     def compare_attr(self, neoobj, nixobj):
         if neoobj.name:
@@ -715,9 +715,9 @@ class NixIOWriteTest(NixIOTest):
                                       nixasig)
                     self.assertEqual(nixasig.unit, "mV")
                     self.assertIs(nixasig.dimensions[0].dimension_type,
-                                  nix.DimensionType.Sample)
+                                  nixio.DimensionType.Sample)
                     self.assertIs(nixasig.dimensions[1].dimension_type,
-                                  nix.DimensionType.Set)
+                                  nixio.DimensionType.Set)
                     self.assertEqual(nixasig.dimensions[0].unit, "s")
                     self.assertEqual(nixasig.dimensions[0].label, "time")
                     self.assertEqual(nixasig.dimensions[0].offset, 0)
@@ -734,9 +734,9 @@ class NixIOWriteTest(NixIOTest):
                                       nixisig)
                     self.assertEqual(nixisig.unit, "nA")
                     self.assertIs(nixisig.dimensions[0].dimension_type,
-                                  nix.DimensionType.Range)
+                                  nixio.DimensionType.Range)
                     self.assertIs(nixisig.dimensions[1].dimension_type,
-                                  nix.DimensionType.Set)
+                                  nixio.DimensionType.Set)
                     self.assertEqual(nixisig.dimensions[0].unit, "ms")
                     self.assertEqual(nixisig.dimensions[0].label, "time")
 
@@ -779,11 +779,11 @@ class NixIOWriteTest(NixIOTest):
                                            neo_waveforms[spk, chan, t])
 
         self.assertIs(nix_waveforms.dimensions[0].dimension_type,
-                      nix.DimensionType.Set)
+                      nixio.DimensionType.Set)
         self.assertIs(nix_waveforms.dimensions[1].dimension_type,
-                      nix.DimensionType.Set)
+                      nixio.DimensionType.Set)
         self.assertIs(nix_waveforms.dimensions[2].dimension_type,
-                      nix.DimensionType.Sample)
+                      nixio.DimensionType.Sample)
 
         # no time dimension specified when creating - defaults to 1 s
         wf_time_dim = nix_waveforms.dimensions[2].unit
@@ -1011,7 +1011,7 @@ class NixIOReadTest(NixIOTest):
             mtag_st.name, mtag_st.name+".metadata"
         )
         mtag_st.metadata = mtag_st_md
-        mtag_st_md.create_property("t_stop", nix.Value(max(times_da).item()+1))
+        mtag_st_md.create_property("t_stop", nixio.Value(max(times_da).item()+1))
 
         neo_blocks = self.io.read_all_blocks()
         self.compare_blocks(neo_blocks, nix_blocks)

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -578,7 +578,9 @@ class NixIOWriteTest(NixIOTest):
                     unit = Unit()
                     rcg.units.append(unit)
         nixblocks = self.io.write_all_blocks(blocks)
-        self.compare_blocks(blocks, nixblocks)
+        # Purpose of test is name generation
+        #  Comparing everything takes too long
+        # self.compare_blocks(blocks, nixblocks)
 
     def test_annotations_write(self):
         """

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -33,19 +33,22 @@ class NixIOTest(unittest.TestCase):
         if os.path.exists(self.filename):
             os.remove(self.filename)
 
-    def check_signal_dataarrays(self, neosig, dalist):
+    def check_segment_group(self, neoseg, nixgroup):
+        pass
+
+    def check_signal_dataarrays(self, neosig, nixdalist):
         """
         Check if a Neo Analog or IrregularlySampledSignal matches a list of
         NIX DataArrays.
 
         :param neosig: Neo Analog or IrregularlySampledSignal
-        :param dalist: List of DataArrays
+        :param nixdalist: List of DataArrays
         """
-        nixmd = dalist[0].metadata
-        self.assertTrue(all(nixmd is da.metadata for da in dalist))
+        nixmd = nixdalist[0].metadata
+        self.assertTrue(all(nixmd is da.metadata for da in nixdalist))
         neounit = str(neosig.dimensionality)
         for sig, da in zip(np.transpose(neosig),
-                           sorted(dalist, key=lambda d: d.name)):
+                           sorted(nixdalist, key=lambda d: d.name)):
             self.check_equal_attr(neosig, da)
             for neov, nixv in zip(sig, da):
                 self.assertAlmostEqual(neov, nixv)

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -74,25 +74,6 @@ class NixIOTest(unittest.TestCase):
         :param neoblock: A Neo block
         :param nixblock: The corresponding NIX block
         """
-        neorcgs = neoblock.recordingchannelgroups
-        nixrcgs = list(src for src in nixblock.sources
-                       if src.type == "neo.recordingchannelgroup")
-        self.assertEqual(len(neorcgs), len(nixrcgs))
-        for neorcg in neorcgs:
-            if neorcg.name:
-                self.assertIn(neorcg.name, nixblock.sources)
-            else:
-                self.anon_warn()
-
-        neounits = dict((un.name, un) for rcg in neorcgs for un in rcg.units)
-        nixunits = dict((un.name, un) for rcg in nixrcgs for un in rcg.sources
-                        if un.type == "neo.unit")
-        self.assertEqual(len(neounits), len(nixunits))
-        for neout in neounits:
-            if neout:
-                self.compare_attr(neounits[neout], nixunits[neout])
-            else:
-                self.anon_warn()
         for neorcg in neoblock.recordingchannelgroups:
             for neounit in neorcg.units:
                 for neost in neounit.spiketrains:

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -768,26 +768,23 @@ class NixIOWriteTest(NixIOTest):
         for nix_label, neo_label in zip(nix_epc_labels, neo_epc_labels):
             self.assertEqual(nix_label, neo_label.decode())
 
-    def check_equal_attr(self, neoobj, nixobj):
-        if neoobj.name:
-            if isinstance(neoobj, (AnalogSignal, IrregularlySampledSignal)):
-                nix_name = ".".join(nixobj.name.split(".")[:-1])
-            else:
-                nix_name = nixobj.name
-            self.assertEqual(neoobj.name, nix_name)
-        self.assertEqual(neoobj.description, nixobj.definition)
-        if hasattr(neoobj, "rec_datetime") and neoobj.rec_datetime:
-            self.assertEqual(neoobj.rec_datetime,
-                             datetime.fromtimestamp(nixobj.created_at))
-        if hasattr(neoobj, "file_datetime") and neoobj.file_datetime:
-            self.assertEqual(neoobj.file_datetime,
-                             datetime.fromtimestamp(
-                                 nixobj.metadata["file_datetime"]))
-        if neoobj.file_origin:
-            self.assertEqual(neoobj.file_origin,
-                             nixobj.metadata["file_origin"])
-        if neoobj.annotations:
-            nixmd = nixobj.metadata
-            for k, v, in neoobj.annotations.items():
-                self.assertEqual(nixmd[k], v)
+
+class NixIOReadTest(NixIOTest):
+
+    def setUp(self):
+        self.filename = "nixio_testfile_read.hd5"
+        self.io = NixIO(self.filename, "rw")
+        self.nixfile = self.io.nix_file
+
+    def test_block_read(self):
+        """
+        Read Block test
+
+        Simple Block with basic attributes.
+        """
+        nix_block = self.nixfile.create_block(name=self.rword(),
+                                              desription=self.rsentence())
+        neo_blocks = self.io.read_all_blocks()
+        self.assertEqual(len(self.io.read_all_blocks()), 1)
+        self.check_equal_attr(neo_blocks[0], nix_block)
 

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -33,29 +33,6 @@ class NixIOTest(unittest.TestCase):
         if os.path.exists(self.filename):
             os.remove(self.filename)
 
-    def check_equal_attr(self, neoobj, nixobj):
-        if neoobj.name:
-            if isinstance(neoobj, (AnalogSignal, IrregularlySampledSignal)):
-                nix_name = ".".join(nixobj.name.split(".")[:-1])
-            else:
-                nix_name = nixobj.name
-            self.assertEqual(neoobj.name, nix_name)
-        self.assertEqual(neoobj.description, nixobj.definition)
-        if hasattr(neoobj, "rec_datetime") and neoobj.rec_datetime:
-            self.assertEqual(neoobj.rec_datetime,
-                             datetime.fromtimestamp(nixobj.created_at))
-        if hasattr(neoobj, "file_datetime") and neoobj.file_datetime:
-            self.assertEqual(neoobj.file_datetime,
-                             datetime.fromtimestamp(
-                                 nixobj.metadata["file_datetime"]))
-        if neoobj.file_origin:
-            self.assertEqual(neoobj.file_origin,
-                             nixobj.metadata["file_origin"])
-        if neoobj.annotations:
-            nixmd = nixobj.metadata
-            for k, v, in neoobj.annotations.items():
-                self.assertEqual(nixmd[k], v)
-
     def check_signal_dataarrays(self, neosig, dalist):
         """
         Check if a Neo Analog or IrregularlySampledSignal matches a list of
@@ -92,6 +69,29 @@ class NixIOTest(unittest.TestCase):
                 self.assertEqual(timedim.unit,
                                  str(sig.ticks.dimensionality))
             self.assertIsInstance(chandim, nix.SetDimension)
+
+    def check_equal_attr(self, neoobj, nixobj):
+        if neoobj.name:
+            if isinstance(neoobj, (AnalogSignal, IrregularlySampledSignal)):
+                nix_name = ".".join(nixobj.name.split(".")[:-1])
+            else:
+                nix_name = nixobj.name
+            self.assertEqual(neoobj.name, nix_name)
+        self.assertEqual(neoobj.description, nixobj.definition)
+        if hasattr(neoobj, "rec_datetime") and neoobj.rec_datetime:
+            self.assertEqual(neoobj.rec_datetime,
+                             datetime.fromtimestamp(nixobj.created_at))
+        if hasattr(neoobj, "file_datetime") and neoobj.file_datetime:
+            self.assertEqual(neoobj.file_datetime,
+                             datetime.fromtimestamp(
+                                 nixobj.metadata["file_datetime"]))
+        if neoobj.file_origin:
+            self.assertEqual(neoobj.file_origin,
+                             nixobj.metadata["file_origin"])
+        if neoobj.annotations:
+            nixmd = nixobj.metadata
+            for k, v, in neoobj.annotations.items():
+                self.assertEqual(nixmd[k], v)
 
     @staticmethod
     def rdate():

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -223,7 +223,7 @@ class NixIOTest(unittest.TestCase):
         self.assertEqual(mtag.positions.unit, str(event.units.dimensionality))
         for neol, nixl in zip(event.labels,
                               mtag.positions.dimensions[0].labels):
-            self.assertEqual(neol, nixl)
+            self.assertEqual(str(neol), str(nixl))
 
     def compare_spiketrain_mtag(self, spiketrain, mtag):
         self.assertEqual(mtag.type, "neo.spiketrain")

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1147,13 +1147,23 @@ class NixIOReadTest(NixIOTest):
                     st.sources.append(nixrcg)
                     st.sources.append(nixunit)
 
-            # pick a few signals to point to this rcg
+            # pick a few signal groups to point to this rcg
             allsigs = list(da for da in blk.data_arrays
                            if da.type in ["neo.analogsignal",
                                           "neo.irregularlysampledsignal"])
-            randsigs = np.random.choice(allsigs, 5, False)
-            for sig in randsigs:
-                sig.sources.append(nixrcg)
+            # group signals that have the same md section
+            grouped_sigs = {}
+            for sig in allsigs:
+                groupname = sig.metadata.name
+                if groupname in grouped_sigs:
+                    grouped_sigs[groupname].append(sig)
+                else:
+                    grouped_sigs[groupname] = [sig]
+            grouped_sigs = list(grouped_sigs.values())
+            randsiggroups = np.random.choice(grouped_sigs, 5, False)
+            for siggroup in randsiggroups:
+                for sig in siggroup:
+                    sig.sources.append(nixrcg)
 
             neo_blocks = self.io.read_all_blocks()
             self.compare_blocks(neo_blocks, nix_blocks)

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -105,9 +105,13 @@ class NixIOTest(unittest.TestCase):
             for neounit in neorcg.units:
                 nixunit = nixrcg.sources[neounit.name]
                 neosts = list(st.name for st in neounit.spiketrains)
-                nixsts = list(mt.name for mt in nixblock.multi_tags
+                nixsts = list(mt for mt in nixblock.multi_tags
                               if mt.type == "neo.spiketrain" and
                               nixunit.name in mt.sources)
+                # SpikeTrains must also reference RCG
+                for nixst in nixsts:
+                    self.assertIn(nixrcg.name, nixst.sources)
+                nixsts = list(st.name for st in nixsts)
                 self.assertEqual(len(neosts), len(nixsts))
                 for neoname in neosts:
                     if neoname:

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -880,4 +880,10 @@ class NixIOReadTest(NixIOTest):
         mtag_st.metadata = mtag_st_md
         mtag_st_md.create_property("t_stop", nix.Value(max(times_da).item()+1))
 
+        # ===== Read and validate =====
+
         neo_blocks = self.io.read_all_blocks()
+        for neo_block, nix_block in zip(neo_blocks, nix_blocks):
+            self.check_equal_attr(neo_block, nix_block)
+            for neo_seg, nix_grp in zip(neo_block.segments, nix_block.groups):
+                self.check_equal_attr(neo_seg, nix_grp)


### PR DESCRIPTION
The basic NIX reader is ready. Like the writer, the reader only works on the full data tree. Partial reading is not implemented yet, so one can not, for instance, read a single group or signal from a NIX file and have it converted to the Neo equivalent.

## Assumptions
The reader also assumes that the objects in the NIX file conform to the rules set by the writer (see issue #35). This may change in the future if necessary. Specifically, the reader has the following expectations:

1. NIX objects which can match to more than one Neo object are expected to have their `type` attribute set to the Neo object they represent. For example, DataArays are expected to have either `type = "neo.analogsignal"` or `type = "neo.irregularlysampledsignal"`.
    - This requirement can be relaxed for signals, since their type could possibly be inferred by the types of the dimensions.
    - Similarly for MultiTags, their type (Event, Epoch, or SpikeTrain) could be inferred by the existence of extents (Epoch), or a time dimension with a sampling interval (SpikeTrain).
    - Lacking any of the above however, in the case of arbitrary NIX data, it's probably not trivial to determine which Neo object best represents a NIX object.
2. NIX DataArrays that represent Neo Signal objects are expected to to be grouped by a common metadata section. When reading, DataArrays that refer to the same metadata section are converted to a single AnalogSignal or IrregularlySampledSignal.

## Mapping change
After the discussion in issue #34, the mapping was slightly changed. RecordingChannelGroups and Units are both converted to Source objects, as before. What has changed from the original mapping specification is that the Sources representing Units are now children of the Sources representing RCGs (the relationship is mapped directly).
As in the original mapping, for each SpikeTrain referenced by a Unit, the corresponding MultiTag contains a reference, in its sources list, to both the Source object representing the Unit and the Source object representing the RCG from the original Neo data tree.

## Tests
Tests for the reader as not as exhaustive as for the writer. There is one all encompassing read test that creates a fully featured NIX data tree, reads it into Neo, and checks the resulting Neo data against the original NIX equivalents.

### Comparison methods for tests
The test file now contains a series of methods that compare a Neo data tree to a NIX data tree for equivalence, based on our defined mapping. I have tested these methods rather rigorously, but some minor bugs may still be present. These methods are the result of my early attempt to write a function that tests for equality between Neo and NIX objects (see issue #8). They're not simple and certainly not "elegant", but they're very convenient for testing and they essentially encode our mapping specification.