### PR TITLE
Name generation fix

### DIFF
--- a/neonix/convert.py
+++ b/neonix/convert.py
@@ -36,7 +36,7 @@ def main():
         if blocks:
             if verbose:
                 print_neo(blocks)
-            nixfilename = os.path.splitext(datafilename)[0]+"_nix.h5"
+            nixfilename = datafilename.replace(".", "_")+"_nix.h5"
             try:
                 print("Writing data to {}".format(nixfilename))
                 nixio = NixIO(nixfilename, mode="ow")

--- a/neonix/convert.py
+++ b/neonix/convert.py
@@ -2,10 +2,15 @@ from __future__ import print_function
 import os
 import sys
 import neo
+from datetime import datetime
 from neonix.io.nixio import NixIO
+
+errorfile = "nixio_error.log"
 
 
 def main():
+    printerr("Starting conversion task at {}".
+             format(datetime.now().isoformat()))
     if "-v" in sys.argv:
         verbose = True
     else:
@@ -17,12 +22,12 @@ def main():
             print("File type: {}".format(reader.name))
             data = reader.read()
         except OSError:
-            printerr("\tNOTICE: file {} does not have an extension "
+            printerr("NOTICE: file {} does not have an extension "
                      "known to Neo.".format(datafilename))
             continue
         except Exception as exc:
-            printerr("\tERROR reading file {}.".format(datafilename))
-            printerr("\t     - {}".format(exc))
+            printerr("ERROR reading file {}.".format(datafilename))
+            printerr("     - {}".format(exc))
             continue
         blocks = []
         try:
@@ -44,9 +49,9 @@ def main():
                 print("\tDONE: file converted and saved to {}".
                       format(datafilename, nixfilename))
             except Exception as exc:
-                printerr("\tERROR: The following error occurred during "
+                printerr("ERROR: The following error occurred during "
                          "conversion of file {}.".format(datafilename))
-                printerr("\t      - {}".format(exc))
+                printerr("      - {}".format(exc))
         else:
             print("File does not contain Blocks. Skipping.")
 
@@ -79,7 +84,8 @@ def print_neo(blocks):
 
 
 def printerr(message):
-    print(message, file=sys.stderr)
+    with open(errorfile, "a") as logfile:
+        print(message, file=logfile)
 
 
 if __name__ == "__main__":

--- a/neonix/convert.py
+++ b/neonix/convert.py
@@ -39,14 +39,16 @@ def main():
             nixfilename = os.path.splitext(datafilename)[0]+"_nix.h5"
             try:
                 print("Writing data to {}".format(nixfilename))
-                nixfile = NixIO(nixfilename)
-                nixfile.write_all_blocks(blocks)
+                nixio = NixIO(nixfilename, mode="ow")
+                nixio.write_all_blocks(blocks)
                 print("\tDONE: file converted and saved to {}".
                       format(datafilename, nixfilename))
             except Exception as exc:
                 printerr("\tERROR: The following error occurred during "
                          "conversion of file {}.".format(datafilename))
                 printerr("\t      - {}".format(exc))
+        else:
+            print("File does not contain Blocks. Skipping.")
 
 
 def print_neo(blocks):

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -147,12 +147,15 @@ class NixIO(BaseIO):
                              if da.type == "neo.analogsignal")
         nix_asigs = self._get_referers(nix_source, all_nix_asigs)
         neo_asigs = self._get_mapped_objects(nix_asigs)
+        # deduplicate by name
+        neo_asigs = list(dict((s.name, s) for s in neo_asigs).values())
         rcg.analogsignals.extend(neo_asigs)
 
         all_nix_isigs = list(da for da in parent_block.data_arrays
                              if da.type == "neo.irregularlysampledsignal")
         nix_isigs = self._get_referers(nix_source, all_nix_isigs)
         neo_isigs = self._get_mapped_objects(nix_isigs)
+        neo_isigs = list(dict((s.name, s) for s in neo_isigs).values())
         rcg.irregularlysampledsignals.extend(neo_isigs)
         return rcg
 

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -128,7 +128,6 @@ class NixIO(BaseIO):
         neo_attrs["channel_names"] = np.array([c["name"] for c in rec_channels])
         neo_attrs["channel_indexes"] = np.array([c["index"]
                                                  for c in rec_channels])
-        # TODO: Make sure all RCs have the same coordinate units
         if "coordinates" in rec_channels[0]:
             coord_units = rec_channels[0]["coordinates.units"]
             coord_values = list(c["coordinates"] for c in rec_channels)
@@ -182,14 +181,11 @@ class NixIO(BaseIO):
         :param nix_da_group: a list of NIX DataArray objects
         :return: a Neo Signal object
         """
-        # TODO: Handle NIX signals which share name with number suffix
         nix_da_group = sorted(nix_da_group, key=lambda d: d.name)
         neo_attrs = self._nix_attr_to_neo(nix_da_group[0])
         neo_attrs["name"] = nix_da_group[0].metadata.name
         unit = nix_da_group[0].unit
-        # TODO: Make sure all DAs have the same unit
         neo_type = nix_da_group[0].type
-        # TODO: Make sure all DAs have the same type
         signaldata = pq.Quantity(np.transpose(nix_da_group), unit)
         timedim = self._get_time_dimension(nix_da_group[0])
         if timedim is None:
@@ -212,7 +208,6 @@ class NixIO(BaseIO):
                 signal=signaldata, times=times, **neo_attrs
             )
         else:
-            # TODO: Multiple Signal objects (Generalised reader)
             return None
         for da in nix_da_group:
             self.object_map[da.id] = neo_signal
@@ -241,7 +236,6 @@ class NixIO(BaseIO):
                 )
                 eest.left_sweep = wfda.metadata["left_sweep"]
         else:
-            # TODO: Infer type from attributes (Generalised reader)
             return None
         self.object_map[nix_mtag.id] = eest
         return eest

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -72,7 +72,6 @@ class NixIO(BaseIO):
                        "'ow' (Overwrite).".format(mode))
         self.nix_file = nixio.File.open(self.filename, filemode)
         self.object_map = {}
-        self.name_conflicts = []
 
     def __del__(self):
         self.nix_file.close()

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -119,27 +119,16 @@ class NixIOTest(unittest.TestCase):
                     else:
                         self.anon_warn()
 
-        for neoseg, nixgroup in zip(neoblock.segments, nixblock.groups):
+        # Events and Epochs must reference all Signals in the Group (NIX only)
+        for nixgroup in nixblock.groups:
             nixevep = list(mt for mt in nixgroup.multi_tags
                            if mt.type in ["neo.event", "neo.epoch"])
-            for asig in neoseg.analogsignals:
-                if asig.name:
-                    _, nsig = np.shape(asig)
-                    for idx in range(nsig):
-                        signame = "{}.{}".format(asig.name, idx)
-                        for nee in nixevep:
-                            self.assertIn(signame, nee.references)
-                else:
-                    self.anon_warn()
-            for isig in neoseg.irregularlysampledsignals:
-                if isig.name:
-                    _, nsig = np.shape(isig)
-                    for idx in range(nsig):
-                        signame = "{}.{}".format(isig.name, idx)
-                        for nee in nixevep:
-                            self.assertIn(signame, nee.references)
-                else:
-                    self.anon_warn()
+            nixsigs = list(da.name for da in nixgroup.data_arrays
+                           if da.type in ["neo.analogsignal",
+                                          "neo.irregularlysampledsignal"])
+            for nee in nixevep:
+                for ns in nixsigs:
+                    self.assertIn(ns, nee.references)
 
     def compare_segment_group(self, neoseg, nixgroup):
         self.compare_attr(neoseg, nixgroup)

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -612,7 +612,7 @@ class NixIOWriteTest(NixIOTest):
             seg.events.append(Event(name=name, times=times))
             seg.spiketrains.append(SpikeTrain(times=times, t_stop=pq.s,
                                               units=pq.s))
-            nixblock = self.io.write_block(block)
+        nixblock = self.io.write_block(block)
 
     def test_annotations_write(self):
         """

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -97,7 +97,7 @@ class NixIOTest(unittest.TestCase):
                     self.assertIn(neoname, nixasigs)
                 else:
                     nneoanon += 1
-            autoname = "{}.AnalogSignal".format(nixblock.name)
+            autoname = "neo.AnalogSignal"
             nixanon = sum(1 for n in nixasigs if autoname in n)
             self.assertEqual(nneoanon, nixanon)
 
@@ -113,7 +113,7 @@ class NixIOTest(unittest.TestCase):
                     self.assertIn(neoname, nixisigs)
                 else:
                     nneoanon += 1
-            autoname = "{}.IrregularlySampledSignal".format(nixblock.name)
+            autoname = "neo.IrregularlySampledSignal"
             nixanon = sum(1 for n in nixisigs if autoname in n)
             self.assertEqual(nneoanon, nixanon)
 
@@ -136,7 +136,7 @@ class NixIOTest(unittest.TestCase):
                     if neoname:
                         self.assertIn(neoname, nixsts)
                 neoanon = sum(1 for n in neosts if not n)
-                autoname = "{}.SpikeTrain".format(nixblock.name)
+                autoname = "neo.SpikeTrain"
                 nixanon = sum(1 for n in nixsts if autoname in n)
                 self.assertEqual(neoanon, nixanon)
 

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -580,7 +580,7 @@ class NixIOWriteTest(NixIOTest):
         nixblocks = self.io.write_all_blocks(blocks)
         # Purpose of test is name generation
         #  Comparing everything takes too long
-        # self.compare_blocks(blocks, nixblocks)
+        self.compare_blocks(blocks, nixblocks)
 
     def test_annotations_write(self):
         """
@@ -1093,7 +1093,7 @@ class NixIOReadTest(NixIOTest):
         neo_blocks = self.io.read_all_blocks()
         self.assertEqual(len(neo_blocks), 1)
         self.compare_attr(neo_blocks[0], nix_block)
-        # self.compare_blocks(neo_blocks, [nix_block])
+        self.compare_blocks(neo_blocks, [nix_block])
 
     def test_all_read(self):
         """

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -75,6 +75,36 @@ class NixIOTest(unittest.TestCase):
         :param nixblock: The corresponding NIX block
         """
         for neorcg in neoblock.recordingchannelgroups:
+            nixrcg = nixblock.sources[neorcg.name]
+            # AnalogSignals referencing RCG
+            neoasigs = list(sig.name for sig in neorcg.analogsignals)
+            nixasigs = list(set(da.metadata.name for da in nixblock.data_arrays
+                                if da.type == "neo.analogsignal" and
+                                nixrcg in da.sources))
+
+            self.assertEqual(len(neoasigs), len(nixasigs))
+            for neoname in neoasigs:
+                if neoname:
+                    self.assertIn(neoname, nixasigs)
+                else:
+                    self.anon_warn()
+
+            # IrregularlySampledSignals referencing RCG
+            neoisigs = list(sig.name for sig in neorcg.irregularlysampledsignals)
+            nixisigs = list(set(da.metadata.name for da in nixblock.data_arrays
+                                if da.type == "neo.irregularlysampledsignal" and
+                                nixrcg in da.sources))
+            self.assertEqual(len(neoisigs), len(nixisigs))
+            for neoname in neoisigs:
+                if neoname:
+                    self.assertIn(neoname, nixisigs)
+                else:
+                    self.anon_warn()
+
+            # SpikeTrains referencing RCG and Units
+
+
+
             for neounit in neorcg.units:
                 for neost in neounit.spiketrains:
                     if neost.name:

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -102,35 +102,18 @@ class NixIOTest(unittest.TestCase):
                     self.anon_warn()
 
             # SpikeTrains referencing RCG and Units
-
-
-
             for neounit in neorcg.units:
-                for neost in neounit.spiketrains:
-                    if neost.name:
-                        nixst = nixblock.multi_tags[neost.name]
-                        self.assertIn(neounit.name, nixst.sources)
-                        self.assertIn(neorcg.name, nixst.sources)
+                nixunit = nixrcg.sources[neounit.name]
+                neosts = list(st.name for st in neounit.spiketrains)
+                nixsts = list(mt.name for mt in nixblock.multi_tags
+                              if mt.type == "neo.spiketrain" and
+                              nixunit.name in mt.sources)
+                self.assertEqual(len(neosts), len(nixsts))
+                for neoname in neosts:
+                    if neoname:
+                        self.assertIn(neoname, nixsts)
                     else:
                         self.anon_warn()
-            for neoasig in neorcg.analogsignals:
-                if neoasig.name:
-                    nixsiggroup = [da for da in nixblock.data_arrays
-                                   if da.type == "neo.analogsignal" and
-                                   da.metadata.name == neoasig.name]
-                    for nixasig in nixsiggroup:
-                        self.assertIn(neorcg.name, nixasig.sources)
-                else:
-                    self.anon_warn()
-            for neoisig in neorcg.irregularlysampledsignals:
-                if neoisig.name:
-                    nixsiggroup = [da for da in nixblock.data_arrays
-                                   if da.type == "neo.irregularlysampledsignal"
-                                   and da.metadata.name == neoisig.name]
-                    for nixisig in nixsiggroup:
-                        self.assertIn(neorcg.name, nixisig.sources)
-                else:
-                    self.anon_warn()
 
         for neoseg, nixgroup in zip(neoblock.segments, nixblock.groups):
             nixevep = list(mt for mt in nixgroup.multi_tags

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -578,7 +578,9 @@ class NixIOWriteTest(NixIOTest):
                     unit = Unit()
                     rcg.units.append(unit)
         nixblocks = self.io.write_all_blocks(blocks)
-        self.compare_blocks(blocks, nixblocks)
+        # Purpose of test is name generation
+        #  Comparing everything takes too long
+        # self.compare_blocks(blocks, nixblocks)
 
     def test_annotations_write(self):
         """

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -309,6 +309,7 @@ class NixIOTest(unittest.TestCase):
         for neol, nixl in zip(event.labels,
                               mtag.positions.dimensions[0].labels):
             # Dirty. Should find the root cause instead
+            # Only happens in 3.2
             if isinstance(neol, bytes):
                 neol = neol.decode()
             if isinstance(nixl, bytes):

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -586,14 +586,8 @@ class NixIOWriteTest(NixIOTest):
         """
         Test resolution of naming conflicts from Neo files.
 
-        The following scenario exists in several sample files:
-            > Block
-                > Segment
-                    > AnalogSignal (name: 'foo')
-                > Segment
-                    > AnalogSignal (name: 'foo')
-
-        The writer should resolve the naming conflict between the signals.
+        Object names in Neo may not be unique. The writer should resolve
+        naming conflicts.
         """
         block = Block()
         nsegs = 10

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -105,9 +105,13 @@ class NixIOTest(unittest.TestCase):
             for neounit in neorcg.units:
                 nixunit = nixrcg.sources[neounit.name]
                 neosts = list(st.name for st in neounit.spiketrains)
-                nixsts = list(mt.name for mt in nixblock.multi_tags
+                nixsts = list(mt for mt in nixblock.multi_tags
                               if mt.type == "neo.spiketrain" and
                               nixunit.name in mt.sources)
+                # SpikeTrains must also reference RCG
+                for nixst in nixsts:
+                    self.assertIn(nixrcg.name, nixst.sources)
+                nixsts = list(st.name for st in nixsts)
                 self.assertEqual(len(neosts), len(nixsts))
                 for neoname in neosts:
                     if neoname:


### PR DESCRIPTION
This PR changes the way NIX objects are named in write methods. New method `_create_name` works as follows:
  - If the Neo object has a name attribute, it is used as a *basename*.
      - Otherwise, the *basename* is `neo.Type` (e.g., `neo.Block`).
  - If the *basename* is unique on the NIX Block, it is selected as the final name for the object.
      - If it is not unique, the suffix `-1` is appended to the *basename* (e.g., `neo.Block-1`) and uniqueness is checked again.
      - If the name with the suffix is again not unique (an object with that name already exists on the Block), the number is incremented until a suitable name is found.

A test has also been added to check that no conflicts occur when writing Neo objects that share the same name.
The methods that test for equivalence between Neo and NIX object trees have also been adjusted to account for the new name generation scheme.

The conversion script, `convert.py`, has been updated to print more meaningful errors, log the erros to a file, and now supports a `verbose` mode which prints a representation of the nested Neo objects being written. This is to help with testing and debugging.

Closes #29.
Closes #22.