### PR TITLE
Lazy loading

### DIFF
--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -170,6 +170,16 @@ class NixIO(BaseIO):
     def read_spiketrain(self, path, cascade, lazy=False):
         return self.read_eest(path, lazy)
 
+    def read_unit(self, path, cascade, lazy=False):
+        nix_source = self._get_object_at(path)
+        neo_unit = self._source_unit_to_neo(nix_source)
+        if cascade:
+            # TODO: Set references (loaded STs) or paths (not loaded STs)
+            pass
+        if lazy:
+            self._lazy_loaded.append(path)
+        return neo_unit
+
     def _block_to_neo(self, nix_block):
         neo_attrs = self._nix_attr_to_neo(nix_block)
         neo_block = Block(**neo_attrs)

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -890,8 +890,16 @@ class NixIO(BaseIO):
             self._lazy_loaded.pop(objidx)
 
     def _find_lazy_loaded(self, obj):
+        """
+        Finds the index of an object in the _lazy_loaded list by comparing the
+        path attribute. Returns None if the object is not in the list.
+
+        :param obj: The object to find
+        :return: The index of the object in the _lazy_loaded list or None if it
+        was not added
+        """
         for idx, llobj in enumerate(self._lazy_loaded):
-            if (type(llobj) is type(obj)) and (llobj is obj):
+            if llobj.path == obj.path:
                 return idx
         else:
             return None

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -384,22 +384,23 @@ class NixIO(BaseIO):
         neoobj = self.get(path, cascade=True, lazy=lazy)
         return neoobj
 
-    def write_block(self, neo_block):
+    def write_block(self, bl, parent_path=None):
         """
-        Convert ``neo_block`` to the NIX equivalent and write it to the file.
+        Convert ``bl`` to the NIX equivalent and write it to the file.
 
-        :param neo_block: Neo block to be written
+        :param bl: Neo block to be written
+        :param parent_path: Unused for blocks
         :return: The new NIX Block
         """
-        attr = self._neo_attr_to_nix(neo_block, self.nix_file.blocks)
+        attr = self._neo_attr_to_nix(bl, self.nix_file.blocks)
         nix_block = self.nix_file.create_block(attr["name"], attr["type"])
         nix_block.definition = attr["definition"]
         object_path = "/" + nix_block.name
-        self._object_map[id(neo_block)] = nix_block
+        self._object_map[id(bl)] = nix_block
         self._write_attr_annotations(nix_block, attr, object_path)
-        for segment in neo_block.segments:
+        for segment in bl.segments:
             self.write_segment(segment, object_path)
-        for rcg in neo_block.recordingchannelgroups:
+        for rcg in bl.recordingchannelgroups:
             self.write_recordingchannelgroup(rcg, object_path)
         return nix_block
 
@@ -414,36 +415,36 @@ class NixIO(BaseIO):
         nix_blocks = list(map(self.write_block, neo_blocks))
         return nix_blocks
 
-    def write_segment(self, segment, parent_path):
+    def write_segment(self, seg, parent_path=None):
         """
-        Convert the provided ``segment`` to a NIX Group and write it to the NIX
+        Convert the provided ``seg`` to a NIX Group and write it to the NIX
         file at the location defined by ``parent_path``.
 
-        :param segment: Neo segment to be written
-        :param parent_path: Path to the parent of the new segment
+        :param seg: Neo seg to be written
+        :param parent_path: Path to the parent of the new seg
         :return: The newly created NIX Group
         """
         parent_block = self._get_object_at(parent_path)
-        attr = self._neo_attr_to_nix(segment, parent_block.groups)
+        attr = self._neo_attr_to_nix(seg, parent_block.groups)
         nix_group = parent_block.create_group(attr["name"], attr["type"])
         nix_group.definition = attr["definition"]
         object_path = parent_path + "/segments/" + nix_group.name
-        self._object_map[id(segment)] = nix_group
+        self._object_map[id(seg)] = nix_group
         self._write_attr_annotations(nix_group, attr, object_path)
-        for anasig in segment.analogsignals:
+        for anasig in seg.analogsignals:
             self.write_analogsignal(anasig, object_path)
-        for irsig in segment.irregularlysampledsignals:
+        for irsig in seg.irregularlysampledsignals:
             self.write_irregularlysampledsignal(irsig, object_path)
-        for ep in segment.epochs:
+        for ep in seg.epochs:
             self.write_epoch(ep, object_path)
-        for ev in segment.events:
+        for ev in seg.events:
             self.write_event(ev, object_path)
-        for sptr in segment.spiketrains:
+        for sptr in seg.spiketrains:
             self.write_spiketrain(sptr, object_path)
 
         return nix_group
 
-    def write_recordingchannelgroup(self, rcg, parent_path):
+    def write_recordingchannelgroup(self, rcg, parent_path=None):
         """
         Convert the provided ``rcg`` (RecordingChannelGroup) to a NIX Source
         and write it to the NIX file at the location defined by ``parent_path``.
@@ -506,7 +507,7 @@ class NixIO(BaseIO):
 
         return nix_source
 
-    def write_analogsignal(self, anasig, parent_path):
+    def write_analogsignal(self, anasig, parent_path=None):
         """
         Convert the provided ``anasig`` (AnalogSignal) to a list of NIX
         DataArray objects and write them to the NIX file at the location defined
@@ -563,7 +564,7 @@ class NixIO(BaseIO):
         self._object_map[id(anasig)] = nix_data_arrays
         return nix_data_arrays
 
-    def write_irregularlysampledsignal(self, irsig, parent_path):
+    def write_irregularlysampledsignal(self, irsig, parent_path=None):
         """
         Convert the provided ``irsig`` (IrregularlySampledSignal) to a list of
         NIX DataArray objects and write them to the NIX file at the location
@@ -618,7 +619,7 @@ class NixIO(BaseIO):
         self._object_map[id(irsig)] = nix_data_arrays
         return nix_data_arrays
 
-    def write_epoch(self, ep, parent_path):
+    def write_epoch(self, ep, parent_path=None):
         """
         Convert the provided ``ep`` (Epoch) to a NIX MultiTag and write it to
         the NIX file at the location defined by ``parent_path``.
@@ -669,7 +670,7 @@ class NixIO(BaseIO):
         )
         return nix_multi_tag
 
-    def write_event(self, ev, parent_path):
+    def write_event(self, ev, parent_path=None):
         """
         Convert the provided ``ev`` (Event) to a NIX MultiTag and write it to
         the NIX file at the location defined by ``parent_path``.
@@ -709,7 +710,7 @@ class NixIO(BaseIO):
         )
         return nix_multi_tag
 
-    def write_spiketrain(self, sptr, parent_path):
+    def write_spiketrain(self, sptr, parent_path=None):
         """
         Convert the provided ``sptr`` (SpikeTrain) to a NIX MultiTag and write
         it to the NIX file at the location defined by ``parent_path``.
@@ -780,7 +781,7 @@ class NixIO(BaseIO):
 
         return nix_multi_tag
 
-    def write_unit(self, ut, parent_path):
+    def write_unit(self, ut, parent_path=None):
         """
         Convert the provided ``ut`` (Unit) to a NIX Source and write it to the
         NIX file at the parent RCG.

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -241,7 +241,7 @@ class NixIO(BaseIO):
         if neo_type == "neo.analogsignal"\
                 or isinstance(timedim, nixio.SampledDimension):
             if lazy:
-                sampling_period = pq.Quantity(0, timedim.unit)
+                sampling_period = pq.Quantity(1, timedim.unit)
                 t_start = pq.Quantity(0, timedim.unit)
             else:
                 sampling_period = pq.Quantity(timedim.sampling_interval,
@@ -297,7 +297,7 @@ class NixIO(BaseIO):
                 wftime = self._get_time_dimension(wfda)
                 if lazy:
                     eest.waveforms = pq.Quantity(np.empty(0), wfda.unit)
-                    eest.sampling_period = pq.Quantity(0, wftime.unit)
+                    eest.sampling_period = pq.Quantity(1, wftime.unit)
                     eest.left_sweep = 0
                 else:
                     eest.waveforms = pq.Quantity(wfda, wfda.unit)

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -203,12 +203,6 @@ class NixIO(BaseIO):
             neo_attrs["coordinates"] = pq.Quantity(coord_values, coord_units)
         rcg = RecordingChannelGroup(**neo_attrs)
         self._object_map[nix_source.id] = rcg
-
-        nix_units = list(src for src in nix_source.sources
-                         if src.type == "neo.unit")
-        neo_units = list(self._source_unit_to_neo(nixut)
-                         for nixut in nix_units)
-        rcg.units.extend(neo_units)
         return rcg
 
     def _source_unit_to_neo(self, nix_unit):
@@ -331,7 +325,6 @@ class NixIO(BaseIO):
                 children = LazyList(self, lazy, chpaths)
             setattr(neo_obj, neocontainer, children)
 
-        # TODO: Handle non-loaded referenced objects and lazy cascading
         if isinstance(neo_obj, RecordingChannelGroup):
             # set references to signals
             parent_block_path = "/" + path.split("/")[1]

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -356,6 +356,7 @@ class NixIO(BaseIO):
                 children = LazyList(self, lazy, chpaths)
             setattr(neo_obj, neocontainer, children)
 
+        # TODO: Handle non-loaded referenced objects and lazy cascading
         if isinstance(neo_obj, RecordingChannelGroup):
             # set references to signals
             parent_block_path = "/" + path.split("/")[1]

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -209,37 +209,12 @@ class NixIO(BaseIO):
         neo_units = list(self._source_unit_to_neo(nixut)
                          for nixut in nix_units)
         rcg.units.extend(neo_units)
-
-        # referenced signals
-        # all_nix_asigs = list(da for da in parent_block.data_arrays
-        #                      if da.type == "neo.analogsignal")
-        # nix_asigs = self._get_referers(nix_source, all_nix_asigs)
-        # neo_asigs = self._get_mapped_objects(nix_asigs)
-        # deduplicate by name
-        # neo_asigs = list(dict((s.name, s) for s in neo_asigs).values())
-        # rcg.analogsignals.extend(neo_asigs)
-
-        # all_nix_isigs = list(da for da in parent_block.data_arrays
-        #                      if da.type == "neo.irregularlysampledsignal")
-        # nix_isigs = self._get_referers(nix_source, all_nix_isigs)
-        # neo_isigs = self._get_mapped_objects(nix_isigs)
-        # neo_isigs = list(dict((s.name, s) for s in neo_isigs).values())
-        # rcg.irregularlysampledsignals.extend(neo_isigs)
-        # rcg.create_many_to_one_relationship()
         return rcg
 
     def _source_unit_to_neo(self, nix_unit):
         neo_attrs = self._nix_attr_to_neo(nix_unit)
         neo_unit = Unit(**neo_attrs)
         self._object_map[nix_unit.id] = neo_unit
-
-        # referenced spiketrains
-        # all_nix_sts = list(mtag for mtag in parent_block.multi_tags
-        #                    if mtag.type == "neo.spiketrain")
-        # nix_sts = self._get_referers(nix_unit, all_nix_sts)
-        # neo_sts = self._get_mapped_objects(nix_sts)
-        # neo_unit.spiketrains.extend(neo_sts)
-        # neo_unit.create_many_to_one_relationship()
         return neo_unit
 
     def _signal_da_to_neo(self, nix_da_group, lazy):

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -94,7 +94,7 @@ class NixIO(BaseIO):
 
     def _group_to_neo(self, nix_group):
         neo_attrs = self._nix_attr_to_neo(nix_group)
-        neo_segment = Block(**neo_attrs)
+        neo_segment = Segment(**neo_attrs)
         self.object_map[nix_group.id] = neo_segment
         nix_grouped_signals = self._group_signals(nix_group.data_arrays)
         signals = list(

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -648,7 +648,7 @@ class NixIO(BaseIO):
             wf_data = list(wf.magnitude for wf in
                            list(wfgroup for wfgroup in sptr.waveforms))
             waveforms_da = parent_block.create_data_array(
-                attr["name"]+".waveforms" "neo.waveforms", data=wf_data
+                attr["name"]+".waveforms", "neo.waveforms", data=wf_data
             )
             wf_unit = self._get_units(sptr.waveforms)
             waveforms_da.unit = wf_unit

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -372,6 +372,9 @@ class NixIO(BaseIO):
         read_func = getattr(self, "read_" + neotype)
         return read_func(path, cascade, lazy)
 
+    def load_lazy_object(self, obj):
+        pass
+
     def load_lazy_cascade(self, path, lazy):
         """
         Loads the object at the location specified by the path and all children.

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -373,8 +373,7 @@ class NixIO(BaseIO):
         return read_func(path, cascade, lazy)
 
     def load_lazy_object(self, obj):
-
-        pass
+        return self.get(obj.path, cascade=False, lazy=False)
 
     def load_lazy_cascade(self, path, lazy):
         """
@@ -884,11 +883,18 @@ class NixIO(BaseIO):
             self._add_annotations(attr["annotations"], metadata)
 
     def _update_lazy_loaded(self, obj, lazy):
-        if lazy and obj not in self._lazy_loaded:
-            obj.path = obj
+        objidx = self._find_lazy_loaded(obj)
+        if lazy and objidx is None:
             self._lazy_loaded.append(obj)
-        elif not lazy and obj in self._lazy_loaded:
-            self._lazy_loaded.remove(obj)
+        elif not lazy and objidx is not None:
+            self._lazy_loaded.pop(objidx)
+
+    def _find_lazy_loaded(self, obj):
+        for idx, llobj in enumerate(self._lazy_loaded):
+            if (type(llobj) is type(obj)) and (llobj is obj):
+                return idx
+        else:
+            return None
 
     @staticmethod
     def _neo_attr_to_nix(neo_obj, container):

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -146,6 +146,7 @@ class NixIO(BaseIO):
         neo_signal = self._signal_da_to_neo(nix_data_arrays, lazy)
         if lazy:
             self._lazy_loaded.append(path)
+        return neo_signal
 
     def read_analogsignal(self, path, cascade, lazy=False):
         return self.read_signal(path, lazy)
@@ -153,18 +154,21 @@ class NixIO(BaseIO):
     def read_irregularlysampledsignal(self, path, cascade, lazy=False):
         return self.read_signal(path, lazy)
 
-    def read_epoch(self, path, cascade, lazy=False):
+    def read_eest(self, path, lazy=False):
         nix_mtag = self._get_object_at(path)
-        neo_epoch = self._mtag_eest_to_neo(nix_mtag, lazy)
+        neo_eest = self._mtag_eest_to_neo(nix_mtag, lazy)
         if lazy:
             self._lazy_loaded.append(path)
-        return neo_epoch
+        return neo_eest
+
+    def read_epoch(self, path, cascade, lazy=False):
+        return self.read_eest(path, lazy)
 
     def read_event(self, path, cascade, lazy=False):
-        pass
+        return self.read_eest(path, lazy)
 
     def read_spiketrain(self, path, cascade, lazy=False):
-        pass
+        return self.read_eest(path, lazy)
 
     def _block_to_neo(self, nix_block):
         neo_attrs = self._nix_attr_to_neo(nix_block)

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -450,10 +450,6 @@ class NixIOTest(unittest.TestCase):
 
 class NixIOWriteTest(NixIOTest):
 
-    # TODO: Use neo.test.tools
-    # TODO: Use neo.test.iotest.common_io_test
-    # TODO: Use neo.test.generate_datasets
-
     def setUp(self):
         self.filename = "nixio_testfile_write.h5"
         self.io = NixIO(self.filename, "ow")

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -10,11 +10,12 @@
 import os
 from datetime import datetime
 import unittest
+from time import time
+import string
+import itertools
 
 import numpy as np
 import quantities as pq
-import string
-import itertools
 
 import nixio
 from neo.core import (Block, Segment, RecordingChannelGroup, AnalogSignal,
@@ -1140,36 +1141,52 @@ class NixIOReadTest(NixIOTest):
         reader, and check for equality.
         """
         nix_blocks = self._create_full_nix()
+        print("Cascade - Greedy loading")
+        start = time()
         neo_blocks = self.io.read_all_blocks(cascade=True, lazy=False)
+        print("Reading took {}".format(time() - start))
+        start = time()
         self.compare_blocks(neo_blocks, nix_blocks)
+        print("Comparison took {}".format(time() - start))
 
     def test_lazyload_fullcascade_read(self):
         """
         Read everything lazily: Lazy integration test with all features
         """
         nix_blocks = self._create_full_nix()
+        print("Cascade - Lazy loading")
+        start = time()
         neo_blocks = self.io.read_all_blocks(cascade=True, lazy=True)
-        print(neo_blocks[0].recordingchannelgroups[0].analogsignals)
-        print(self.io._lazy_loaded)
+        print("Reading took {}".format(time() - start))
+        start = time()
         self.compare_blocks(neo_blocks, nix_blocks)
+        print("Comparison took {}".format(time() - start))
 
     def test_lazyload_lazycascade_read(self):
         """
         Read everything lazily with lazy cascade
         """
         nix_blocks = self._create_full_nix()
+        print("Lazy cascade - Lazy loading")
+        start = time()
         neo_blocks = self.io.read_all_blocks(cascade="lazy", lazy=True)
-        print(self.io._lazy_loaded)
+        print("Reading took {}".format(time() - start))
+        start = time()
         self.compare_blocks(neo_blocks, nix_blocks)
+        print("Comparison took {}".format(time() - start))
 
     def test_fullload_lazycascade_read(self):
         """
         Read everything with lazy cascade
         """
         nix_blocks = self._create_full_nix()
+        print("Lazy cascade - Greedy loading")
+        start = time()
         neo_blocks = self.io.read_all_blocks(cascade="lazy", lazy=False)
-        print(self.io._lazy_loaded)
+        print("Reading took {}".format(time() - start))
+        start = time()
         self.compare_blocks(neo_blocks, nix_blocks)
+        print("Comparison took {}".format(time() - start))
 
     def _create_full_nix(self):
         nix_block_a = self.nixfile.create_block(self.rword(10), "neo.block")

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1139,6 +1139,39 @@ class NixIOReadTest(NixIOTest):
         Write all objects to a using nix directly, read them using the NixIO
         reader, and check for equality.
         """
+        nix_blocks = self._create_full_nix()
+        neo_blocks = self.io.read_all_blocks(cascade=True, lazy=False)
+        self.compare_blocks(neo_blocks, nix_blocks)
+
+    def test_lazyload_fullcascade_read(self):
+        """
+        Read everything lazily: Lazy integration test with all features
+        """
+        nix_blocks = self._create_full_nix()
+        neo_blocks = self.io.read_all_blocks(cascade=True, lazy=True)
+        print(neo_blocks[0].recordingchannelgroups[0].analogsignals)
+        print(self.io._lazy_loaded)
+        self.compare_blocks(neo_blocks, nix_blocks)
+
+    def test_lazyload_lazycascade_read(self):
+        """
+        Read everything lazily with lazy cascade
+        """
+        nix_blocks = self._create_full_nix()
+        neo_blocks = self.io.read_all_blocks(cascade="lazy", lazy=True)
+        print(self.io._lazy_loaded)
+        self.compare_blocks(neo_blocks, nix_blocks)
+
+    def test_fullload_lazycascade_read(self):
+        """
+        Read everything with lazy cascade
+        """
+        nix_blocks = self._create_full_nix()
+        neo_blocks = self.io.read_all_blocks(cascade="lazy", lazy=False)
+        print(self.io._lazy_loaded)
+        self.compare_blocks(neo_blocks, nix_blocks)
+
+    def _create_full_nix(self):
         nix_block_a = self.nixfile.create_block(self.rword(10), "neo.block")
         nix_block_a.definition = self.rsentence(5, 10)
         nix_block_b = self.nixfile.create_block(self.rword(10), "neo.block")
@@ -1347,6 +1380,4 @@ class NixIOReadTest(NixIOTest):
             for siggroup in randsiggroups:
                 for sig in siggroup:
                     sig.sources.append(nixrcg)
-
-        neo_blocks = self.io.read_all_blocks(cascade=True, lazy=False)
-        self.compare_blocks(neo_blocks, nix_blocks)
+        return nix_blocks

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1348,5 +1348,5 @@ class NixIOReadTest(NixIOTest):
                 for sig in siggroup:
                     sig.sources.append(nixrcg)
 
-        neo_blocks = self.io.read_all_blocks(True, True)
+        neo_blocks = self.io.read_all_blocks(cascade=True, lazy=False)
         self.compare_blocks(neo_blocks, nix_blocks)

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -444,6 +444,10 @@ class NixIOTest(unittest.TestCase):
 
 class NixIOWriteTest(NixIOTest):
 
+    # TODO: Use neo.test.tools
+    # TODO: Use neo.test.iotest.common_io_test
+    # TODO: Use neo.test.generate_datasets
+
     def setUp(self):
         self.filename = "nixio_testfile_write.hd5"
         self.io = NixIO(self.filename, "ow")

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1184,7 +1184,20 @@ class NixIOReadTest(NixIOTest):
         nix_blocks = self._create_full_nix()
         neo_blocks = self.io.read_all_blocks(cascade="lazy", lazy=False)
         self.compare_blocks(neo_blocks, nix_blocks)
-        print("Comparison took {}".format(time() - start))
+
+    def test_nocascade(self):
+        """
+        Read a Block without cascading
+        """
+        nix_block = self.nixfile.create_block(self.rword(), "neo.block")
+        nix_block.definition = self.rsentence()
+        for idx in range(5):
+            group = nix_block.create_group(self.rword(), "neo.segment")
+            group.definition = self.rsentence()
+        blockpath = "/" + nix_block.name
+        neo_block = self.io.read_block(blockpath, cascade=False, lazy=False)
+        self.assertEqual(len(neo_block.segments), 0)
+        self.compare_attr(neo_block, nix_block)
 
     def _create_full_nix(self):
         nix_block_a = self.nixfile.create_block(self.rword(10), "neo.block")

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1145,50 +1145,33 @@ class NixIOReadTest(NixIOTest):
         reader, and check for equality.
         """
         nix_blocks = self._create_full_nix()
-        print("Cascade - Greedy loading")
-        start = time()
         neo_blocks = self.io.read_all_blocks(cascade=True, lazy=False)
-        print("Reading took {}".format(time() - start))
-        start = time()
         self.compare_blocks(neo_blocks, nix_blocks)
-        print("Comparison took {}".format(time() - start))
 
     def test_lazyload_fullcascade_read(self):
         """
         Read everything lazily: Lazy integration test with all features
         """
         nix_blocks = self._create_full_nix()
-        print("Cascade - Lazy loading")
-        start = time()
         neo_blocks = self.io.read_all_blocks(cascade=True, lazy=True)
         print("Reading took {}".format(time() - start))
         start = time()
         self.compare_blocks(neo_blocks, nix_blocks)
-        print("Comparison took {}".format(time() - start))
 
     def test_lazyload_lazycascade_read(self):
         """
         Read everything lazily with lazy cascade
         """
         nix_blocks = self._create_full_nix()
-        print("Lazy cascade - Lazy loading")
-        start = time()
         neo_blocks = self.io.read_all_blocks(cascade="lazy", lazy=True)
-        print("Reading took {}".format(time() - start))
-        start = time()
         self.compare_blocks(neo_blocks, nix_blocks)
-        print("Comparison took {}".format(time() - start))
 
     def test_fullload_lazycascade_read(self):
         """
         Read everything with lazy cascade
         """
         nix_blocks = self._create_full_nix()
-        print("Lazy cascade - Greedy loading")
-        start = time()
         neo_blocks = self.io.read_all_blocks(cascade="lazy", lazy=False)
-        print("Reading took {}".format(time() - start))
-        start = time()
         self.compare_blocks(neo_blocks, nix_blocks)
         print("Comparison took {}".format(time() - start))
 

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -524,7 +524,6 @@ class NixIOWriteTest(NixIOTest):
         neo_block.file_origin = "test_file_origin"
         self.io.write_block(neo_block)
         nix_block = self.io.nix_file.blocks[0]
-
         self.compare_attr(neo_block, nix_block)
 
     def test_anonymous_objects_write(self):

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -450,7 +450,7 @@ class NixIOWriteTest(NixIOTest):
     # TODO: Use neo.test.generate_datasets
 
     def setUp(self):
-        self.filename = "nixio_testfile_write.hd5"
+        self.filename = "nixio_testfile_write.h5"
         self.io = NixIO(self.filename, "ow")
 
     def test_block_write(self):
@@ -1115,7 +1115,7 @@ class NixIOWriteTest(NixIOTest):
 class NixIOReadTest(NixIOTest):
 
     def setUp(self):
-        self.filename = "nixio_testfile_read.hd5"
+        self.filename = "nixio_testfile_read.h5"
         self.io = NixIO(self.filename, "rw")
         self.nixfile = self.io.nix_file
 

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -166,6 +166,8 @@ class NixIOTest(unittest.TestCase):
                 signame = sig.name
             else:
                 signame = self.find_nix_name_signal(sig, data_arrays)
+            if self.io._find_lazy_loaded(sig) is not None:
+                sig = self.io.load_lazy_object(sig)
             dalist = list()
             for idx in itertools.count():
                 nixname = "{}.{}".format(signame, idx)
@@ -173,8 +175,8 @@ class NixIOTest(unittest.TestCase):
                     dalist.append(data_arrays[nixname])
                 else:
                     break
-            _, nasig = np.shape(sig)
-            self.assertEqual(nasig, len(dalist))
+            _, nsig = np.shape(sig)
+            self.assertEqual(nsig, len(dalist))
             self.compare_signal_dalist(sig, dalist)
 
     def find_nix_name_signal(self, neosig, nixsigs):
@@ -246,6 +248,8 @@ class NixIOTest(unittest.TestCase):
                 eestname = eest.name
             else:
                 eestname = self.find_nix_name_eest(eest, mtaglist)
+            if self.io._find_lazy_loaded(eest) is not None:
+                eest = self.io.load_lazy_object(eest)
             mtag = mtaglist[eestname]
             if isinstance(eest, Epoch):
                 self.compare_epoch_mtag(eest, mtag)

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1348,5 +1348,5 @@ class NixIOReadTest(NixIOTest):
                 for sig in siggroup:
                     sig.sources.append(nixrcg)
 
-        neo_blocks = self.io.read_all_blocks()
+        neo_blocks = self.io.read_all_blocks(True, True)
         self.compare_blocks(neo_blocks, nix_blocks)

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -36,6 +36,7 @@ class NixIOTest(unittest.TestCase):
     def compare_blocks(self, neoblocks, nixblocks):
         for neoblock, nixblock in zip(neoblocks, nixblocks):
             self.compare_attr(neoblock, nixblock)
+            self.assertEqual(len(neoblock.segments), len(nixblock.groups))
             for idx, neoseg in enumerate(neoblock.segments):
                 if neoseg.name:
                     nixgrp = nixblock.groups[neoseg.name]

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1154,8 +1154,19 @@ class NixIOReadTest(NixIOTest):
         """
         nix_blocks = self._create_full_nix()
         neo_blocks = self.io.read_all_blocks(cascade=True, lazy=True)
-        print("Reading took {}".format(time() - start))
-        start = time()
+        # data objects should be empty
+        for block in neo_blocks:
+            for seg in block.segments:
+                for asig in seg.analogsignals:
+                    self.assertEqual(len(asig), 0)
+                for isig in seg.irregularlysampledsignals:
+                    self.assertEqual(len(isig), 0)
+                for epoch in seg.epochs:
+                    self.assertEqual(len(epoch), 0)
+                for event in seg.events:
+                    self.assertEqual(len(event), 0)
+                for st in seg.spiketrains:
+                    self.assertEqual(len(st), 0)
         self.compare_blocks(neo_blocks, nix_blocks)
 
     def test_lazyload_lazycascade_read(self):


### PR DESCRIPTION
**NOTE: This PR includes the changes from PR #39**

Lazy loading, lazy cascade, and no cascade are now supported by the reader.
Tests have also been implemented for this functionality.

The old `_<obj>_to_neo` methods now handle attribute conversion and object creation only.

New `read_<obj>` methods that comply with the Neo IO guidelines expose the reader functionality.
These methods take as primary argument a `path`, which is a `/` delimited series of object names and containers, in Neo form. For example, the path to an AnalogSignal object would have the following form:
`/<block name>/segments/<segment name>/analogsignals/<signal name>`

The `_read_cascade` method handles the descent into child objects and the creation of either objects or lazy references accordingly.

`load_lazy_object` and `load_lazy_cascade` have been implemented as described in the Neo IO developers' guide.

Closes #31.