### PR TITLE
Neo common IO tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ env:
     global:
         - CC=gcc-4.8
         - CXX=g++-4.8
-        - NIX_LIBDIR=$PWD/nix/inst/lib
-        - NIX_INCDIR=$PWD/nix/inst/include
-        - export PKG_CONFIG_PATH=$NIX_LIBDIR/pkgconfig
-        - export PYTHONPATH=$PYTHONPATH:$PWD/neo:$PWD/nixpy
+        # - NIX_LIBDIR=$PWD/nix/inst/lib
+        # - NIX_INCDIR=$PWD/nix/inst/include
+        # - export PKG_CONFIG_PATH=$NIX_LIBDIR/pkgconfig
+        # - export PYTHONPATH=$PYTHONPATH:$PWD/neo:$PWD/nixpy
 
 addons:
   apt:
@@ -34,22 +34,22 @@ addons:
 install:
     - pip install numpy quantities coveralls six h5py
     # nix
-    - git clone --depth 1 https://github.com/G-Node/nix.git nix
-    - cd nix
-    - cmake -DCMAKE_INSTALL_PREFIX=./inst -DBUILD_TESTING=OFF .
-    - make
-    - make install
-    - cd ..
+    # - git clone --depth 1 https://github.com/G-Node/nix.git nix
+    # - cd nix
+    # - cmake -DCMAKE_INSTALL_PREFIX=./inst -DBUILD_TESTING=OFF .
+    # - make
+    # - make install
+    # - cd ..
     # nixpy
     - git clone -b pycore --depth 1 https://github.com/G-Node/nixpy.git nixpy
     - cd nixpy
-    - python setup.py build
+    # - python setup.py build
     - cd ..
     # neo
-    - git clone -b apibreak --depth 1 https://github.com/NeuralEnsemble/python-neo neo
-    - cd neo
-    - python setup.py build
-    - cd ..
+    - git clone --depth 1 https://github.com/NeuralEnsemble/python-neo neo
+    # - cd neo
+    # - python setup.py build
+    # - cd ..
 
 script:
     - python setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ addons:
       - g++-4.8
 
 install:
-    - pip install numpy quantities coveralls six
+    - pip install numpy quantities coveralls six h5py
     # nix
     - git clone --depth 1 https://github.com/G-Node/nix.git nix
     - cd nix

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
     - make install
     - cd ..
     # nixpy
-    - git clone --depth 1 https://github.com/G-Node/nixpy.git nixpy
+    - git clone -b pycore --depth 1 https://github.com/G-Node/nixpy.git nixpy
     - cd nixpy
     - python setup.py build
     - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,25 +11,21 @@ matrix:
 
 env:
     global:
-        - CC=gcc-4.8
-        - CXX=g++-4.8
+        # - CC=gcc-4.8
+        # - CXX=g++-4.8
         # - NIX_LIBDIR=$PWD/nix/inst/lib
         # - NIX_INCDIR=$PWD/nix/inst/include
         # - export PKG_CONFIG_PATH=$NIX_LIBDIR/pkgconfig
-        # - export PYTHONPATH=$PYTHONPATH:$PWD/neo:$PWD/nixpy
+        - export PYTHONPATH=$PYTHONPATH:$PWD/neo:$PWD/nixpy
 
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - kalakris-cmake
-      - boost-latest
     packages:
-      - libcppunit-dev
-      - libboost1.55-all-dev
+      # - libcppunit-dev
+      # - libboost1.55-all-dev
       - libhdf5-serial-dev
-      - cmake
-      - g++-4.8
+      # - cmake
+      # - g++-4.8
 
 install:
     - pip install numpy quantities coveralls six h5py
@@ -41,10 +37,10 @@ install:
     # - make install
     # - cd ..
     # nixpy
-    - git clone -b pycore --depth 1 https://github.com/G-Node/nixpy.git nixpy
-    - cd nixpy
+    - git clone -b pycore --depth 1 https://github.com/achilleas-k/nixpy.git nixpy
+    # - cd nixpy
     # - python setup.py build
-    - cd ..
+    # - cd ..
     # neo
     - git clone --depth 1 https://github.com/NeuralEnsemble/python-neo neo
     # - cd neo

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -533,6 +533,16 @@ class NixIO(BaseIO):
         self._write_object(bl, loc)
         self._create_references(bl)
 
+    def write_channelindex(self, chx, loc=""):
+        """
+        Convert the provided ``chx`` (ChannelIndex) to a NIX Source and write it
+        to the NIX file at the location defined by ``loc``.
+
+        :param chx: The Neo ChannelIndex to be written
+        :param loc: Path to the parent of the new CHX
+        """
+        self._write_object(chx, loc)
+
     def write_segment(self, seg, loc=""):
         """
         Convert the provided ``seg`` to a NIX Group and write it to the NIX
@@ -543,14 +553,14 @@ class NixIO(BaseIO):
         """
         self._write_object(seg, loc)
 
-    def write_channelindex(self, chx, loc=""):
+    def write_indices(self, chx, loc=""):
         """
-        Create NIX Source objects to represent channels based on the
+        Create NIX Source objects to represent individual indices based on the
         provided ``chx`` (ChannelIndex) write them to the NIX file at
-        the parent RCG.
+        the parent ChannelIndex object.
 
         :param chx: The Neo ChannelIndex
-        :param loc: Path to the RCG
+        :param loc: Path to the CHX
         """
         nixsource = self._get_mapped_object(chx)
         for idx, channel in enumerate(chx.index):
@@ -654,7 +664,7 @@ class NixIO(BaseIO):
     def _write_cascade(self, neoobj, path=""):
         if isinstance(neoobj, ChannelIndex):
             containers = ["units"]
-            self.write_channelindex(neoobj, path)
+            self.write_indices(neoobj, path)
         elif isinstance(neoobj, Unit):
             containers = []
         else:

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -110,7 +110,7 @@ class NixIO(BaseIO):
             raise ValueError("Invalid mode specified '{}'. "
                              "Valid modes: 'ro' (ReadOnly)', 'rw' (ReadWrite), "
                              "'ow' (Overwrite).".format(mode))
-        self.nix_file = nixio.File.open(self.filename, filemode, backend="hdf5")
+        self.nix_file = nixio.File.open(self.filename, filemode, backend="h5py")
         self._object_map = dict()
         self._lazy_loaded = list()
         self._object_hashes = dict()

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -460,7 +460,11 @@ class NixIO(BaseIO):
         if isinstance(obj, Block):
             containerstr = "/"
         else:
-            containerstr = "/" + type(obj).__name__.lower() + "s/"
+            objtype = type(obj).__name__.lower()
+            if objtype == "channelindex":
+                containerstr = "/channel_indexes/"
+            else:
+                containerstr = "/" + type(obj).__name__.lower() + "s/"
         self.resolve_name_conflicts(obj)
         objpath = loc + containerstr + obj.name
         oldhash = self._object_hashes.get(objpath)

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -1133,7 +1133,12 @@ class NixIO(BaseIO):
         """
         grouppaths = list(".".join(p.split(".")[:-1])
                           for p in paths)
-        return list(set(grouppaths))
+        # deduplicating paths
+        uniquepaths = []
+        for path in grouppaths:
+            if path not in uniquepaths:
+                uniquepaths.append(path)
+        return uniquepaths
 
     @staticmethod
     def _get_referers(nix_obj, obj_list):

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -426,6 +426,8 @@ class NixIO(BaseIO):
             neotype = parts[-2][:-1]
         else:
             neotype = "block"
+        if neotype == "channel_indexe":
+            neotype = "channelindex"
         read_func = getattr(self, "read_" + neotype)
         return read_func(path, cascade, lazy)
 
@@ -650,7 +652,7 @@ class NixIO(BaseIO):
             chanpath = loc + "/channelindex/" + channame
             chanmd = self._get_or_init_metadata(nixchan, chanpath)
             chanmd["index"] = self._to_value(int(channel))
-            if chx.coordinates:
+            if chx.coordinates is not None:
                 coords = chx.coordinates[idx]
                 coordunits = str(coords[0].dimensionality)
                 nixcoordunits = self._to_value(coordunits)

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -92,8 +92,6 @@ class NixIO(BaseIO):
         "units": "sources"
     }
 
-    _read_blocks = 0
-
     def __init__(self, filename, mode="ro"):
         """
         Initialise IO instance and NIX file.
@@ -117,9 +115,6 @@ class NixIO(BaseIO):
         self._lazy_loaded = list()
         self._object_hashes = dict()
         self._read_blocks = 0
-
-    def __del__(self):
-        self.nix_file.close()
 
     def read_all_blocks(self, cascade=True, lazy=False):
         blocks = list()
@@ -1113,7 +1108,7 @@ class NixIO(BaseIO):
             neo_attrs["file_datetime"] = datetime.fromtimestamp(
                 neo_attrs["file_datetime"]
             )
-        neo_attrs["file_origin"] = os.path.basename(self.filename)
+        # neo_attrs["file_origin"] = os.path.basename(self.filename)
         return neo_attrs
 
     @staticmethod

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -114,7 +114,7 @@ class NixIO(BaseIO):
         self._object_map = dict()
         self._lazy_loaded = list()
         self._object_hashes = dict()
-        self._read_blocks = 0
+        self._block_read_counter = 0
 
     def read_all_blocks(self, cascade=True, lazy=False):
         blocks = list()
@@ -125,9 +125,10 @@ class NixIO(BaseIO):
     def read_block(self, path="/", cascade=True, lazy=False):
         if path == "/":
             try:
-                nix_block = self.nix_file.blocks[self._read_blocks]
+                # Use yield?
+                nix_block = self.nix_file.blocks[self._block_read_counter]
                 path += nix_block.name
-                self._read_blocks += 1
+                self._block_read_counter += 1
             except KeyError:
                 return None
         else:

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -251,8 +251,7 @@ class NixIO(BaseIO):
                             if c.type == "neo.channelindex")
         neo_attrs["channel_names"] = np.array([c["name"] for c in rec_channels],
                                               dtype="S")
-        neo_attrs["channel_indexes"] = np.array([c["index"]
-                                                 for c in rec_channels])
+        neo_attrs["index"] = np.array([c["index"] for c in rec_channels])
         if "coordinates" in rec_channels[0]:
             coord_units = rec_channels[0]["coordinates.units"]
             coord_values = list(c["coordinates"] for c in rec_channels)
@@ -628,7 +627,7 @@ class NixIO(BaseIO):
         :param loc: Path to the RCG
         """
         nixsource = self._get_mapped_object(chx)
-        for idx, channel in enumerate(chx.channel_indexes):
+        for idx, channel in enumerate(chx.index):
             if len(chx.channel_names):
                 channame = chx.channel_names[idx]
                 if ((not isinstance(channame, str)) and
@@ -1180,11 +1179,11 @@ class NixIO(BaseIO):
             strupdate(obj.rec_datetime)
             strupdate(obj.file_datetime)
         elif isinstance(obj, ChannelIndex):
-            for idx in obj.channel_indexes:
+            for idx in obj.index:
                 strupdate(idx)
             for n in obj.channel_names:
                 strupdate(n)
-            if hasattr(obj, "coordinates"):
+            if hasattr(obj, "coordinates") and obj.coordinates:
                 for coord in obj.coordinates:
                     for c in coord:
                         strupdate(c)

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -109,9 +109,9 @@ class NixIO(BaseIO):
         elif mode == "ow":
             filemode = nixio.FileMode.Overwrite
         else:
-            ValueError("Invalid mode specified '{}'. "
-                       "Valid modes: 'ro' (ReadOnly)', 'rw' (ReadWrite), "
-                       "'ow' (Overwrite).".format(mode))
+            raise ValueError("Invalid mode specified '{}'. "
+                             "Valid modes: 'ro' (ReadOnly)', 'rw' (ReadWrite), "
+                             "'ow' (Overwrite).".format(mode))
         self.nix_file = nixio.File.open(self.filename, filemode, backend="hdf5")
         self._object_map = dict()
         self._lazy_loaded = list()

--- a/neonix/io/nixio.py
+++ b/neonix/io/nixio.py
@@ -650,7 +650,7 @@ class NixIO(BaseIO):
             chanpath = loc + "/channelindex/" + channame
             chanmd = self._get_or_init_metadata(nixchan, chanpath)
             chanmd["index"] = self._to_value(int(channel))
-            if hasattr(chx, "coordinates"):
+            if chx.coordinates:
                 coords = chx.coordinates[idx]
                 coordunits = str(coords[0].dimensionality)
                 nixcoordunits = self._to_value(coordunits)
@@ -1187,7 +1187,7 @@ class NixIO(BaseIO):
                 strupdate(idx)
             for n in obj.channel_names:
                 strupdate(n)
-            if hasattr(obj, "coordinates") and obj.coordinates:
+            if obj.coordinates is not None:
                 for coord in obj.coordinates:
                     for c in coord:
                         strupdate(c)

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1521,9 +1521,9 @@ class NixIOHashTest(NixIOTest):
     def test_spiketrain_hash(self):
         argfuncs = {"name": self.rword,
                     "description": self.rsentence,
-                    "times": lambda: self.rquant(10, pq.ms),
+                    "times": lambda: self.rquant(10, pq.ms, True),
                     "t_start": lambda: -np.random.random() * pq.sec,
-                    "t_stop": lambda: np.random.random() * pq.sec,
+                    "t_stop": lambda: np.random.random() * 100 * pq.sec,
                     "waveforms": lambda: self.rquant((10, 10, 20), pq.mV),
                     # annotations
                     self.rword(): self.rword,

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -27,6 +27,7 @@ from neo.core import (Block, Segment, RecordingChannelGroup, AnalogSignal,
                       IrregularlySampledSignal, Unit, SpikeTrain, Event, Epoch)
 
 from neonix.io.nixio import NixIO
+from neonix.io.nixio import nixtypes
 
 
 class NixIOTest(unittest.TestCase):
@@ -172,7 +173,7 @@ class NixIOTest(unittest.TestCase):
             timedim = da.dimensions[0]
             chandim = da.dimensions[1]
             if isinstance(neosig, AnalogSignal):
-                self.assertIsInstance(timedim, nixio.SampledDimension)
+                self.assertIsInstance(timedim, nixtypes["SampledDimension"])
                 self.assertEqual(
                     pq.Quantity(timedim.sampling_interval, timedim.unit),
                     neosig.sampling_period
@@ -182,12 +183,12 @@ class NixIOTest(unittest.TestCase):
                     neosig.t_start
                 )
             elif isinstance(neosig, IrregularlySampledSignal):
-                self.assertIsInstance(timedim, nixio.RangeDimension)
+                self.assertIsInstance(timedim, nixtypes["RangeDimension"])
                 np.testing.assert_almost_equal(neosig.times.magnitude,
                                                timedim.ticks)
                 self.assertEqual(timedim.unit,
                                  str(neosig.times.dimensionality))
-            self.assertIsInstance(chandim, nixio.SetDimension)
+            self.assertIsInstance(chandim, nixtypes["SetDimension"])
 
     def compare_eests_mtags(self, eestlist, mtaglist):
         self.assertEqual(len(eestlist), len(mtaglist))
@@ -247,9 +248,10 @@ class NixIOTest(unittest.TestCase):
             self.assertEqual(np.shape(neowf), np.shape(nixwf))
             self.assertEqual(nixwf.unit, str(neowf.units.dimensionality))
             np.testing.assert_almost_equal(neowf.magnitude, nixwf)
-            self.assertIsInstance(nixwf.dimensions[0], nixio.SetDimension)
-            self.assertIsInstance(nixwf.dimensions[1], nixio.SetDimension)
-            self.assertIsInstance(nixwf.dimensions[2], nixio.SampledDimension)
+            self.assertIsInstance(nixwf.dimensions[0], nixtypes["SetDimension"])
+            self.assertIsInstance(nixwf.dimensions[1], nixtypes["SetDimension"])
+            self.assertIsInstance(nixwf.dimensions[2],
+                                  nixtypes["SampledDimension"])
 
     def compare_attr(self, neoobj, nixobj):
         if neoobj.name:

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1547,12 +1547,8 @@ class NixIOPartialWriteTest(NixIOTest):
     def tearDownClass(cls):
         cls.delete_nix_file()
 
-    def setUp(self):
-        self.io = NixIO(self.filename, "ow")
-
     def tearDown(self):
         self.restore_methods()
-        del self.io
 
     def restore_methods(self):
         for name, method in self.original_methods.items():

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1074,10 +1074,10 @@ class NixIOWriteTest(NixIOTest):
                     self.compare_attr(neoseg.analogsignals[0],
                                       nixasig)
                     self.assertEqual(nixasig.unit, "mV")
-                    self.assertIs(nixasig.dimensions[0].dimension_type,
-                                  nixio.DimensionType.Sample)
-                    self.assertIs(nixasig.dimensions[1].dimension_type,
-                                  nixio.DimensionType.Set)
+                    self.assertEqual(nixasig.dimensions[0].dimension_type,
+                                     nixio.DimensionType.Sample)
+                    self.assertEqual(nixasig.dimensions[1].dimension_type,
+                                     nixio.DimensionType.Set)
                     self.assertEqual(nixasig.dimensions[0].unit, "s")
                     self.assertEqual(nixasig.dimensions[0].label, "time")
                     self.assertEqual(nixasig.dimensions[0].offset, 0)
@@ -1093,10 +1093,10 @@ class NixIOWriteTest(NixIOTest):
                     self.compare_attr(neoseg.irregularlysampledsignals[0],
                                       nixisig)
                     self.assertEqual(nixisig.unit, "nA")
-                    self.assertIs(nixisig.dimensions[0].dimension_type,
-                                  nixio.DimensionType.Range)
-                    self.assertIs(nixisig.dimensions[1].dimension_type,
-                                  nixio.DimensionType.Set)
+                    self.assertEqual(nixisig.dimensions[0].dimension_type,
+                                     nixio.DimensionType.Range)
+                    self.assertEqual(nixisig.dimensions[1].dimension_type,
+                                     nixio.DimensionType.Set)
                     self.assertEqual(nixisig.dimensions[0].unit, "ms")
                     self.assertEqual(nixisig.dimensions[0].label, "time")
 
@@ -1138,12 +1138,12 @@ class NixIOWriteTest(NixIOTest):
                     self.assertAlmostEqual(nix_waveforms[spk, chan, t],
                                            neo_waveforms[spk, chan, t])
 
-        self.assertIs(nix_waveforms.dimensions[0].dimension_type,
-                      nixio.DimensionType.Set)
-        self.assertIs(nix_waveforms.dimensions[1].dimension_type,
-                      nixio.DimensionType.Set)
-        self.assertIs(nix_waveforms.dimensions[2].dimension_type,
-                      nixio.DimensionType.Sample)
+        self.assertEqual(nix_waveforms.dimensions[0].dimension_type,
+                         nixio.DimensionType.Set)
+        self.assertEqual(nix_waveforms.dimensions[1].dimension_type,
+                         nixio.DimensionType.Set)
+        self.assertEqual(nix_waveforms.dimensions[2].dimension_type,
+                         nixio.DimensionType.Sample)
 
         # no time dimension specified when creating - defaults to 1 s
         wf_time_dim = nix_waveforms.dimensions[2].unit

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -590,7 +590,6 @@ class NixIOTest(unittest.TestCase):
         return blk
 
 
-# @unittest.skip
 class NixIOWriteTest(NixIOTest):
 
     def setUp(self):
@@ -1311,7 +1310,6 @@ class NixIOWriteTest(NixIOTest):
         self.assertEqual(val, section["val"])
 
 
-# @unittest.skip
 class NixIOReadTest(NixIOTest):
 
     nix_blocks = None
@@ -1420,7 +1418,6 @@ class NixIOReadTest(NixIOTest):
             self.compare_attr(block, nix_block)
 
 
-# @unittest.skip
 class NixIOHashTest(NixIOTest):
 
     def setUp(self):
@@ -1520,7 +1517,6 @@ class NixIOHashTest(NixIOTest):
         self._hash_test(SpikeTrain, argfuncs)
 
 
-# @unittest.skip
 class NixIOPartialWriteTest(NixIOTest):
 
     neo_blocks = None

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -282,9 +282,14 @@ class NixIOTest(unittest.TestCase):
                 os.makedirs(dirloc)
         else:
             filename = "nixio_testfile.h5"
+
+        exists = os.path.exists(filename)
         cls.filename = filename
         nixfile = NixIO(cls.filename, "rw")
         cls.io = nixfile
+
+        if exists:
+            return cls.io.nix_file.blocks
 
         nix_block_a = nixfile.nix_file.create_block(cls.rword(10), "neo.block")
         nix_block_a.definition = cls.rsentence(5, 10)
@@ -499,7 +504,7 @@ class NixIOTest(unittest.TestCase):
     @classmethod
     def delete_nix_file(cls):
         del cls.io
-        os.remove(cls.filename)
+        # os.remove(cls.filename)
 
     @staticmethod
     def rdate():
@@ -598,7 +603,7 @@ class NixIOWriteTest(NixIOTest):
 
     def tearDown(self):
         del self.io
-        os.remove(self.filename)
+        # os.remove(self.filename)
 
     def test_block_write(self):
         """
@@ -1324,7 +1329,8 @@ class NixIOReadTest(NixIOTest):
 
     @classmethod
     def tearDownClass(cls):
-        cls.delete_nix_file()
+        # cls.delete_nix_file()
+        pass
 
     def tearDown(self):
         self.restore_methods()
@@ -1534,7 +1540,8 @@ class NixIOPartialWriteTest(NixIOTest):
 
     @classmethod
     def tearDownClass(cls):
-        cls.delete_nix_file()
+        # cls.delete_nix_file()
+        pass
 
     def tearDown(self):
         self.restore_methods()

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -814,7 +814,7 @@ class NixIOWriteTest(NixIOTest):
 
         chx = blk.channel_indexes[0]
         nixchxs = [src for src in nixblk.sources
-                   if src.type == "neo.channelindexes"]
+                   if src.type == "neo.channelindex"]
         self.compare_attr(chx, nixchxs[0])
 
     def test_metadata_structure_write(self):
@@ -945,7 +945,7 @@ class NixIOWriteTest(NixIOTest):
                           if mtag.type == "neo.spiketrain"]
         self.compare_attr(spiketrain, nixspiketrains[0])
         nixchxs = [src for src in nixblk.sources
-                   if src.type == "neo.channelindexes"]
+                   if src.type == "neo.channelindex"]
         self.compare_attr(chx, nixchxs[0])
 
     def test_all_write(self):

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1605,3 +1605,9 @@ class NixIOPartialWriteTest(NixIOTest):
         # self.assertNotEqual(hash_pre, hash_post)
 
         self.compare_blocks(self.neo_blocks, self.io.nix_file.blocks)
+
+
+class CommonTests(BaseTestIO, unittest.TestCase):
+
+    ioclass = NixIO
+

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1417,6 +1417,11 @@ class NixIOReadTest(NixIOTest):
             nix_block = self.io.nix_file.blocks[block.name]
             self.compare_attr(block, nix_block)
 
+    def test_lazy_load_subschema(self):
+        blk = self.io.nix_file.blocks[0]
+        segpath = "/" + blk.name + "/segments/" + blk.groups[0].name
+        self.io.load_lazy_cascade(segpath, lazy=True)
+
 
 class NixIOHashTest(NixIOTest):
 

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -283,13 +283,9 @@ class NixIOTest(unittest.TestCase):
         else:
             filename = "nixio_testfile.h5"
 
-        exists = os.path.exists(filename)
         cls.filename = filename
-        nixfile = NixIO(cls.filename, "rw")
+        nixfile = NixIO(cls.filename, "ow")
         cls.io = nixfile
-
-        if exists:
-            return cls.io.nix_file.blocks
 
         nix_block_a = nixfile.nix_file.create_block(cls.rword(10), "neo.block")
         nix_block_a.definition = cls.rsentence(5, 10)
@@ -504,7 +500,7 @@ class NixIOTest(unittest.TestCase):
     @classmethod
     def delete_nix_file(cls):
         del cls.io
-        # os.remove(cls.filename)
+        os.remove(cls.filename)
 
     @staticmethod
     def rdate():
@@ -603,7 +599,7 @@ class NixIOWriteTest(NixIOTest):
 
     def tearDown(self):
         del self.io
-        # os.remove(self.filename)
+        os.remove(self.filename)
 
     def test_block_write(self):
         """
@@ -1315,7 +1311,7 @@ class NixIOWriteTest(NixIOTest):
         self.assertEqual(val, section["val"])
 
 
-@unittest.skip
+# @unittest.skip
 class NixIOReadTest(NixIOTest):
 
     nix_blocks = None
@@ -1329,8 +1325,7 @@ class NixIOReadTest(NixIOTest):
 
     @classmethod
     def tearDownClass(cls):
-        # cls.delete_nix_file()
-        pass
+        cls.delete_nix_file()
 
     def tearDown(self):
         self.restore_methods()
@@ -1425,7 +1420,7 @@ class NixIOReadTest(NixIOTest):
             self.compare_attr(block, nix_block)
 
 
-@unittest.skip
+# @unittest.skip
 class NixIOHashTest(NixIOTest):
 
     def setUp(self):
@@ -1525,7 +1520,7 @@ class NixIOHashTest(NixIOTest):
         self._hash_test(SpikeTrain, argfuncs)
 
 
-@unittest.skip
+# @unittest.skip
 class NixIOPartialWriteTest(NixIOTest):
 
     neo_blocks = None
@@ -1540,8 +1535,7 @@ class NixIOPartialWriteTest(NixIOTest):
 
     @classmethod
     def tearDownClass(cls):
-        # cls.delete_nix_file()
-        pass
+        cls.delete_nix_file()
 
     def tearDown(self):
         self.restore_methods()
@@ -1617,6 +1611,7 @@ class NixIOPartialWriteTest(NixIOTest):
         # self.assertNotEqual(hash_pre, hash_post)
 
         self.compare_blocks(self.neo_blocks, self.io.nix_file.blocks)
+
 
 @unittest.skip
 class CommonTests(BaseTestIO, unittest.TestCase):

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1325,8 +1325,12 @@ class NixIOReadTest(NixIOTest):
     def tearDownClass(cls):
         cls.delete_nix_file()
 
+    def setUp(self):
+        self.io = NixIO(self.filename, "ro")
+
     def tearDown(self):
         self.restore_methods()
+        del self.io
 
     def restore_methods(self):
         for name, method in self.original_methods.items():
@@ -1543,8 +1547,12 @@ class NixIOPartialWriteTest(NixIOTest):
     def tearDownClass(cls):
         cls.delete_nix_file()
 
+    def setUp(self):
+        self.io = NixIO(self.filename, "ow")
+
     def tearDown(self):
         self.restore_methods()
+        del self.io
 
     def restore_methods(self):
         for name, method in self.original_methods.items():

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1420,7 +1420,13 @@ class NixIOReadTest(NixIOTest):
     def test_lazy_load_subschema(self):
         blk = self.io.nix_file.blocks[0]
         segpath = "/" + blk.name + "/segments/" + blk.groups[0].name
-        self.io.load_lazy_cascade(segpath, lazy=True)
+        segment = self.io.load_lazy_cascade(segpath, lazy=True)
+        self.assertIsInstance(segment, Segment)
+        self.assertEqual(segment.name, blk.groups[0].name)
+        self.assertIs(segment.block, None)
+        self.assertEqual(len(segment.analogsignals[0]), 0)
+        segment = self.io.load_lazy_cascade(segpath, lazy=False)
+        self.assertEqual(np.shape(segment.analogsignals[0]), (100, 3))
 
 
 class NixIOHashTest(NixIOTest):

--- a/neonix/test/test_nixio.py
+++ b/neonix/test/test_nixio.py
@@ -1461,10 +1461,9 @@ class NixIOHashTest(NixIOTest):
                     "description": self.rsentence,
                     "index": lambda: np.random.random(10).tolist(),
                     "channel_names": lambda: self.rsentence(10).split(" "),
-                    # CHX does not store coordinates
-                    # "coordinates": lambda: [(np.random.random() * pq.cm,
-                    #                          np.random.random() * pq.cm,
-                    #                          np.random.random() * pq.cm)]*10,
+                    "coordinates": lambda: [(np.random.random() * pq.cm,
+                                             np.random.random() * pq.cm,
+                                             np.random.random() * pq.cm)]*10,
                     # annotations
                     self.rword(): self.rword,
                     self.rword(): lambda: self.rquant((10, 10), pq.mV)}
@@ -1609,7 +1608,6 @@ class NixIOPartialWriteTest(NixIOTest):
         self.compare_blocks(self.neo_blocks, self.io.nix_file.blocks)
 
 
-@unittest.skip
 class CommonTests(BaseTestIO, unittest.TestCase):
 
     ioclass = NixIO


### PR DESCRIPTION
Common IO tests now run successfully.

RecordingChannelGroup refactored to ChannelIndex.

The IO now explicitly uses the Python backend of NIXPy.
